### PR TITLE
autotools: fix static linking with pkg-config

### DIFF
--- a/Project/GNU/CLI/configure.ac
+++ b/Project/GNU/CLI/configure.ac
@@ -177,14 +177,15 @@ if test "$with_dll" != "yes"; then
 			LIBS="$LIBS $(libmediainfo-config LIBS)"
 		fi
 	else
-		if pkg-config --exists lib$with_libmediainfo_name; then
+		if pkg-config --exists libmediainfo; then
 			CXXFLAGS="$CXXFLAGS $(pkg-config --cflags libmediainfo)"
 			if test "$enable_staticlibs" = "yes"; then
 				with_mediainfolib="system (static)"
-				LIBS="$LIBS $(pkg-config --variable=Libs_Static lib$with_libmediainfo_name)"
+				LIBS="$LIBS $(pkg-config --variable=Libs_Static libmediainfo)"
+				LIBS="$LIBS $(pkg-config --static --libs libmediainfo)"
 			else
 				with_mediainfolib="system"
-				LIBS="$LIBS $(pkg-config --libs lib$with_libmediainfo_name)"
+				LIBS="$LIBS $(pkg-config --libs libmediainfo)"
 			fi
 		else
 			AC_MSG_ERROR([libmediainfo configuration is not found])
@@ -224,6 +225,7 @@ else
 		if test "$enable_staticlibs" = "yes"; then
 			with_zenlib="system (static)"
 			LIBS="$LIBS $(pkg-config --variable=Libs_Static libzen)"
+			LIBS="$LIBS $(pkg-config --static --libs libzen)"
 		else
 			with_zenlib="system"
 			LIBS="$LIBS $(pkg-config --libs libzen)"

--- a/Project/GNU/GUI/configure.ac
+++ b/Project/GNU/GUI/configure.ac
@@ -296,6 +296,7 @@ if test "$with_dll" != "yes"; then
             if test "$enable_staticlibs" = "yes"; then
                 with_mediainfolib="system (static)"
                 LIBS="$LIBS $(pkg-config --variable=Libs_Static libmediainfo)"
+                LIBS="$LIBS $(pkg-config --static --libs libmediainfo)"
             else
                 with_mediainfolib="system"
                 LIBS="$LIBS $(pkg-config --libs libmediainfo)"
@@ -329,6 +330,7 @@ else
         if test "$enable_staticlibs" = "yes"; then
             with_zenlib="system (static)"
             LIBS="$LIBS $(pkg-config --variable=Libs_Static libzen)"
+            LIBS="$LIBS $(pkg-config --static --libs libzen)"
         else
             with_zenlib="system"
             LIBS="$LIBS $(pkg-config --libs libzen)"


### PR DESCRIPTION
The CMake scripts for libzen and libmediainfo don't use Libs_Static
so LIBS would always be empty. Additionally, the proper way to get
static libcurl libs is to use '--static --libs' when invoking
pkg-config.

To prevent regressions, do both checks for Libs_Static variable
and the new '--static --libs' and use both. It's kind of overlinking,
maybe, but should prevent regressions for now.