### PR TITLE
Add ZenLib and MediaInfoLib as dependencies for macOS in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,11 @@ https://guide.macports.org/#installing
 port install autoconf automake libtool pkgconfig zlib wxWidgets-3.0
 ```
 
+*MediaArea tools*
+* [libzen](#zenlib)
+* [libmediainfo](#mediainfolib)
+
+
 ### Dependencies under Linux
 
 #### Listing


### PR DESCRIPTION
Signed-off-by: Maxime Gervais <gervais.maxime@gmail.com>

Fix #313