### PR TITLE
Updated manpage to include JSON,EBUCore,PBCore as options.

### DIFF
--- a/Project/OBS/deb7.debian/mediainfo.pod
+++ b/Project/OBS/deb7.debian/mediainfo.pod
@@ -121,6 +121,30 @@ Full information Display with HTML tags
 
 Full information Display with XML tags
 
+=item B<--Output=OLDXML>
+
+Full information Display with XML tags using the older MediaInfo schema
+
+=item B<--Output=JSON>
+
+Full information Display using JSON
+
+=item B<--Output=EBUCore>
+
+Full information Display with EBUCore compliant XML tags
+
+=item B<--Output=EBUCore_JSON>
+
+Full information Display with EBUCore 1.8 compliant JSON
+
+=item B<--Output=PBCore>
+
+Full information Display with PBCore compliant XML tags
+
+=item B<--Output=PBCore2>
+
+Full information Display with PBCore 2.0 compliant XML tags
+
 =item B<--Inform=FMT>
 
 Template defined information display.

--- a/Project/OBS/deb9.debian/mediainfo.pod
+++ b/Project/OBS/deb9.debian/mediainfo.pod
@@ -121,6 +121,30 @@ Full information Display with HTML tags
 
 Full information Display with XML tags
 
+=item B<--Output=OLDXML>
+
+Full information Display with XML tags using the older MediaInfo schema
+
+=item B<--Output=JSON>
+
+Full information Display using JSON
+
+=item B<--Output=EBUCore>
+
+Full information Display with EBUCore compliant XML tags
+
+=item B<--Output=EBUCore_JSON>
+
+Full information Display with EBUCore 1.8 compliant JSON
+
+=item B<--Output=PBCore>
+
+Full information Display with PBCore compliant XML tags
+
+=item B<--Output=PBCore2>
+
+Full information Display with PBCore 2.0 compliant XML tags
+
 =item B<--Inform=FMT>
 
 Template defined information display.

--- a/debian/mediainfo.pod
+++ b/debian/mediainfo.pod
@@ -121,6 +121,30 @@ Full information Display with HTML tags
 
 Full information Display with XML tags
 
+=item B<--Output=OLDXML>
+
+Full information Display with XML tags using the older MediaInfo schema
+
+=item B<--Output=JSON>
+
+Full information Display using JSON
+
+=item B<--Output=EBUCore>
+
+Full information Display with EBUCore compliant XML tags
+
+=item B<--Output=EBUCore_JSON>
+
+Full information Display with EBUCore 1.8 compliant JSON
+
+=item B<--Output=PBCore>
+
+Full information Display with PBCore compliant XML tags
+
+=item B<--Output=PBCore2>
+
+Full information Display with PBCore 2.0 compliant XML tags
+
 =item B<--Inform=FMT>
 
 Template defined information display.


### PR DESCRIPTION
I've added the following options for "--output" in the manpages:

  * OLDXML
  * JSON
  * EBUCore / EBUCore_JSON
  * PBCore / PBCore2

All 3 "mediainfo.pod" files I've found seemed to be identical.
So I've changed one and copied it over the others.