### PR TITLE
Allow sub-elements in tree views, fix

### DIFF
--- a/Source/GUI/VCL/GUI_Main.cpp
+++ b/Source/GUI/VCL/GUI_Main.cpp
@@ -745,7 +745,7 @@ void __fastcall TMainF::Refresh(TTabSheet *Page)
                             if (A==__T("Yes") && Champ_Pos+1<ChampsCount)
                                 Hide=I->Get(FilePos, (stream_t)StreamKind, StreamPos, Champ_Pos+1, Info_Name_Text).find_first_not_of(__T(' '))>Level;
 
-                            if (Level)
+                            if (Level && Level!=(size_t)-1)
                                 D=D.substr(Level);
 
                             if(Level==Tree.size() && Tree.back()->GetLastChild())


### PR DESCRIPTION
Addition to https://github.com/MediaArea/MediaInfo/pull/384, when the library returns a bad name (with only spaces).