### PR TITLE
Android GUI: Use raw language when generating XML

### DIFF
--- a/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/Core.kt
+++ b/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/Core.kt
@@ -34,6 +34,7 @@ object Core {
     }
 
     fun createReport(fd: Int, name: String): ByteArray {
+        mi.Option("Language", "")
         mi.Option("Inform", "MIXML")
         mi.Option("Input_Compressed", "")
         mi.Option("Inform_Compress", "zlib+base64")


### PR DESCRIPTION
(For coherency between calls, fixed in MediaInfoLib)

Signed-off-by: Maxime Gervais <gervais.maxime@gmail.com>