### PR TITLE
configure.ac: Use PKG_CONFIG variable before using pkg-config

### DIFF
--- a/Project/GNU/CLI/configure.ac
+++ b/Project/GNU/CLI/configure.ac
@@ -71,8 +71,8 @@ if test -e ../../../../ZenLib/Project/GNU/Library/libzen-config; then
 elif test "$(libzen-config Exists)" = "yes" ; then
 	enable_unicode="$(libzen-config Unicode)"
 else
-	if pkg-config --exists libzen; then
-		enable_unicode="$(pkg-config --variable=Unicode libzen)"
+	if ${PKG_CONFIG:-pkg-config} --exists libzen; then
+		enable_unicode="$(${PKG_CONFIG:-pkg-config} --variable=Unicode libzen)"
 	else
 		AC_MSG_ERROR([libzen configuration is not found])
 	fi
@@ -178,15 +178,15 @@ if test "$with_dll" != "yes"; then
 			LIBS="$LIBS $(libmediainfo-config LIBS)"
 		fi
 	else
-		if pkg-config --exists libmediainfo; then
-			CXXFLAGS="$CXXFLAGS $(pkg-config --cflags libmediainfo)"
+		if ${PKG_CONFIG:-pkg-config} --exists libmediainfo; then
+			CXXFLAGS="$CXXFLAGS $(${PKG_CONFIG:-pkg-config} --cflags libmediainfo)"
 			if test "$enable_staticlibs" = "yes"; then
 				with_mediainfolib="system (static)"
-				LIBS="$LIBS $(pkg-config --variable=Libs_Static libmediainfo)"
-				LIBS="$LIBS $(pkg-config --static --libs libmediainfo)"
+				LIBS="$LIBS $(${PKG_CONFIG:-pkg-config} --variable=Libs_Static libmediainfo)"
+				LIBS="$LIBS $(${PKG_CONFIG:-pkg-config} --static --libs libmediainfo)"
 			else
 				with_mediainfolib="system"
-				LIBS="$LIBS $(pkg-config --libs libmediainfo)"
+				LIBS="$LIBS $(${PKG_CONFIG:-pkg-config} --libs libmediainfo)"
 			fi
 		else
 			AC_MSG_ERROR([libmediainfo configuration is not found])
@@ -220,16 +220,16 @@ elif test "$(libzen-config Exists)" = "yes" ; then
 		LIBS="$LIBS $(libzen-config LIBS)"
 	fi
 else
-	if pkg-config --exists libzen; then
-		CXXFLAGS="$CXXFLAGS $(pkg-config --cflags libzen)"
-		MediaInfoLib_CXXFLAGS="$MediaInfoLib_CXXFLAGS $(pkg-config --cflags libzen)"
+	if ${PKG_CONFIG:-pkg-config} --exists libzen; then
+		CXXFLAGS="$CXXFLAGS $(${PKG_CONFIG:-pkg-config} --cflags libzen)"
+		MediaInfoLib_CXXFLAGS="$MediaInfoLib_CXXFLAGS $(${PKG_CONFIG:-pkg-config} --cflags libzen)"
 		if test "$enable_staticlibs" = "yes"; then
 			with_zenlib="system (static)"
-			LIBS="$LIBS $(pkg-config --variable=Libs_Static libzen)"
-			LIBS="$LIBS $(pkg-config --static --libs libzen)"
+			LIBS="$LIBS $(${PKG_CONFIG:-pkg-config} --variable=Libs_Static libzen)"
+			LIBS="$LIBS $(${PKG_CONFIG:-pkg-config} --static --libs libzen)"
 		else
 			with_zenlib="system"
-			LIBS="$LIBS $(pkg-config --libs libzen)"
+			LIBS="$LIBS $(${PKG_CONFIG:-pkg-config} --libs libzen)"
 		fi
 	else
 		AC_MSG_ERROR([libzen configuration is not found])


### PR DESCRIPTION
This can solve a very specific issue where pkg-config might be pkgconf and a specific flag might be needed for the output to match pkg-config

