### PR TITLE
Use system icons instead of built-in

### DIFF
--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -187,12 +187,13 @@ MainWindow::MainWindow(QStringList filesnames, int viewasked, QWidget *parent) :
 #endif
 
     //tests
-    ui->actionQuit->setIcon(style()->standardIcon(QStyle::SP_DialogCloseButton));
-    ui->actionClose_All->setIcon(style()->standardIcon(QStyle::SP_DialogCloseButton));
-    ui->actionOpen->setIcon(QIcon(":/icon/openfile.svg"));
-    ui->actionOpen_Folder->setIcon(QIcon(":/icon/opendir.svg"));
-    ui->actionAbout->setIcon(QIcon(":/icon/about.svg"));
-    ui->actionExport->setIcon(QIcon(":/icon/export.svg"));
+    ui->actionQuit->setIcon(QIcon::fromTheme("application-exit"));
+    ui->actionClose_All->setIcon(QIcon::fromTheme("dialog-close"));
+    ui->actionOpen->setIcon(QIcon::fromTheme("document-open"));
+    ui->actionOpen_Folder->setIcon(QIcon::fromTheme("document-open-folder"));
+    ui->actionAbout->setIcon(QIcon::fromTheme("help-about"));
+    ui->actionExport->setIcon(QIcon::fromTheme("document-export"));
+    ui->actionPreferences->setIcon(QIcon::fromTheme("configure"));
 
     menuView = new QMenu();
    QActionGroup* menuItemGroup = new QActionGroup(this);
@@ -209,7 +210,7 @@ MainWindow::MainWindow(QStringList filesnames, int viewasked, QWidget *parent) :
 
    buttonView = new QToolButton();
    buttonView->setText("view");
-   buttonView->setIcon(QIcon(":/icon/view.svg"));
+   buttonView->setIcon(QIcon::fromTheme("view-list-details"));
    connect(buttonView, SIGNAL(clicked()), this, SLOT(buttonViewClicked()));
    ui->toolBar->addWidget(buttonView);
 


### PR DESCRIPTION
This PR replaces MediaInfo's built-in icons with icons from the local system theme in the Qt version.

![Screenshot_20211118_144047](https://user-images.githubusercontent.com/43704682/142508366-f818013e-37f7-48cc-9191-b40a39456b89.png)
