### PR TITLE
Add removable-media plug

### DIFF
--- a/Project/Snap/mediainfo/snapcraft.yaml
+++ b/Project/Snap/mediainfo/snapcraft.yaml
@@ -13,6 +13,7 @@ apps:
     plugs:
       - home
       - network
+      - removable-media
 
 parts:
   mediainfo:


### PR DESCRIPTION
https://snapcraft.io/docs/removable-media-interface

This interface will allow mediainfo to access mounted media. This plug is not auto-enabled and requires and explicit command to activate.