### PR TITLE
Fix MSVC2022 project Includes

### DIFF
--- a/Project/MSVC2022/CLI/MediaInfo.vcxproj
+++ b/Project/MSVC2022/CLI/MediaInfo.vcxproj
@@ -144,10 +144,10 @@
     <ResourceCompile Include="MediaInfo_CLI.rc" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\MediaInfoLib\Project\MSVC2019\Library\MediaInfoLib.vcxproj">
+    <ProjectReference Include="..\..\..\..\MediaInfoLib\Project\MSVC2022\Library\MediaInfoLib.vcxproj">
       <Project>{20e0f8d6-213c-460b-b361-9c725cb375c7}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\..\ZenLib\Project\MSVC2019\Library\ZenLib.vcxproj">
+    <ProjectReference Include="..\..\..\..\ZenLib\Project\MSVC2022\Library\ZenLib.vcxproj">
       <Project>{0da1da7d-f393-4e7c-a7ce-cb5c6a67bc94}</Project>
     </ProjectReference>
   </ItemGroup>


### PR DESCRIPTION
The MSVC2022 project Includes point to the MSVC2019 projects for MediaInfoLib and ZenLib. Point to the MSVC2022 projects instead to prevent build failures on systems with only the v143 toolset.