### PR TITLE
Qt GUI: HighDPI support

### DIFF
--- a/Source/GUI/Qt/main.cpp
+++ b/Source/GUI/Qt/main.cpp
@@ -27,6 +27,10 @@ int main(int argc, char *argv[])
     QCoreApplication::setApplicationName("mediainfo-gui");
     QCoreApplication::setApplicationVersion(QString().fromStdString(Ztring(MediaInfo_Version_GUI).To_UTF8()));
 
+#if QT_VERSION >= QT_VERSION_CHECK(5, 6, 0) && QT_VERSION < QT_VERSION_CHECK(6, 0, 0)
+    QApplication::setAttribute(Qt::AA_EnableHighDpiScaling);
+    QApplication::setAttribute(Qt::AA_UseHighDpiPixmaps);
+#endif
 #if defined(_WIN32) && defined(WINAPI_FAMILY) && (WINAPI_FAMILY==WINAPI_FAMILY_APP) //UWP Application
     QApplication::setAttribute(Qt::AA_ImmediateWidgetCreation, true);
     QApplication a(argc, argv);


### PR DESCRIPTION
avoid scaling issues and blurred icons in menus on HighDPI screens
screenshots from KDE, left - no changes (master as is), right - with this fix (noticeable change for round icons)
<img src="https://user-images.githubusercontent.com/947647/225159710-f9a60ff0-e04d-4b2a-865b-835bc1fd5f4e.png" width=400 /><img src="https://user-images.githubusercontent.com/947647/225159714-453ed484-21ff-4a27-ba84-a887eabb4930.png" width=400 />
