### PR TITLE
Qt GUI: fixed QT_VERSION macro usage

### DIFF
--- a/Source/GUI/Qt/configtreetext.cpp
+++ b/Source/GUI/Qt/configtreetext.cpp
@@ -134,7 +134,7 @@ void ConfigTreeText::addField(int i, QString f) {
 }
 
 void ConfigTreeText::removeField(int i, QString f) {
-#if QT_VERSION >= 0x404000
+#if QT_VERSION >= 0x040400
     fields[i].removeOne(f);
 #else
     if(fields[i].indexOf(f))

--- a/Source/GUI/Qt/editsheet.cpp
+++ b/Source/GUI/Qt/editsheet.cpp
@@ -79,11 +79,10 @@ QLayout* EditSheet::createColumn(column c) {
 
     col->widthBox()->setDisabled(ui->checkBoxAdapt->isChecked());
 
-#if QT_VERSION >= 0x403000
+#if QT_VERSION >= 0x040300
     col->setContentsMargins(0,0,0,0);
 #endif
     col->setSpacing(0);
-    col->setMargin(0);
 
     return col;
 }

--- a/Source/GUI/Qt/sheetview.cpp
+++ b/Source/GUI/Qt/sheetview.cpp
@@ -96,15 +96,11 @@ void SheetView::on_tableWidget_itemSelectionChanged()
 {
     ui->comboBox->clear();
     ui->comboBox->addItem(Tr("Summary"),QPoint(-1,-1));
-#if QT_VERSION >= 0x404000
-        if(C->Count_Get(filePos,(stream_t)streamKind) && ui->comboBox->count())
-            ui->comboBox->insertSeparator(ui->comboBox->count());
-#endif
     if(ui->tableWidget->selectedItems().isEmpty())
         return;
     int filePos = ui->tableWidget->selectedItems().at(0)->data(Qt::UserRole).toInt();
     for(int streamKind=0;streamKind<Stream_Max;++streamKind) {
-#if QT_VERSION >= 0x404000
+#if QT_VERSION >= 0x040400
         if(C->Count_Get(filePos,(stream_t)streamKind) && ui->comboBox->count())
             ui->comboBox->insertSeparator(ui->comboBox->count());
 #endif


### PR DESCRIPTION
- [values for `QT_VERSION`](https://doc.qt.io/archives/qt-4.8/qtglobal.html#QT_VERSION) were incorrect (expected Qt 64.x.y instead of Qt 4.x.y)
- drop invalid code under such incorrect version comparison
- drop [deprecated function](https://doc.qt.io/qt-5/qlayout-obsolete.html#setMargin) that was added since Qt 5, but [deprecated in 5.13](https://code.qt.io/cgit/qt/qtbase.git/tree/src/widgets/kernel/qlayout.h?h=v5.15.8-lts-lgpl#n86)
  correct equivalent already existed in the code, just was not called due to incorrect Qt version check