### PR TITLE
Qt GUI: fixed -Wreorder warning

### DIFF
--- a/Source/GUI/Qt/columneditsheet.cpp
+++ b/Source/GUI/Qt/columneditsheet.cpp
@@ -22,8 +22,8 @@ using namespace ZenLib;
 ColumnEditSheet::ColumnEditSheet(column c, int pos, int nb, Core* C, QWidget *parent) :
     QHBoxLayout(parent),
     pos(pos),
-    C(C),
-    col(c)
+    col(c),
+    C(C)
 {
     QLineEdit* lineedit = new QLineEdit(c.name);
     this->addWidget(lineedit);


### PR DESCRIPTION
fixed `-Wreorder` warning detected during build with GCC:
```
In file included from ../../../Source/GUI/Qt/columneditsheet.cpp:7:
../../../Source/GUI/Qt/columneditsheet.h: In constructor ‘ColumnEditSheet::ColumnEditSheet(column, int, int, Core*, QWidget*)’:
../../../Source/GUI/Qt/columneditsheet.h:52:11: warning: ‘ColumnEditSheet::C’ will be initialized after [-Wreorder]
   52 |     Core* C;
      |           ^
../../../Source/GUI/Qt/columneditsheet.h:45:12: warning:   ‘column ColumnEditSheet::col’ [-Wreorder]
   45 |     column col;
      |            ^~~
../../../Source/GUI/Qt/columneditsheet.cpp:22:1: warning:   when initialized here [-Wreorder]
   22 | ColumnEditSheet::ColumnEditSheet(column c, int pos, int nb, Core* C, QWidget *parent) :
      | ^~~~~~~~~~~~~~~
```