### PR TITLE
Qt GUI: get rid of obsolete QRegExp usage

### DIFF
--- a/Source/GUI/Qt/columneditsheet.cpp
+++ b/Source/GUI/Qt/columneditsheet.cpp
@@ -89,7 +89,7 @@ void ColumnEditSheet::fillCombobox() {
     s.truncate((s.indexOf("\n\n")==-1?s.size():s.indexOf("\n\n")));
     QStringList sl = s.split("\n");
     sl.removeAt(0);
-    sl.replaceInStrings(QRegExp(";(.*)"),"");
+    sl.replaceInStrings(QRegularExpression(";(.*)"),"");
     for (int i=0; i<sl.size(); ++i)
         combobox->addItem(sl.at(i),sl.at(i));
     if(stream->itemData(stream->currentIndex()).toInt()==col.stream)

--- a/Source/GUI/Qt/editconfigtreetext.cpp
+++ b/Source/GUI/Qt/editconfigtreetext.cpp
@@ -49,7 +49,7 @@ void EditConfigTreeText::fillToolBox() {
         s.truncate((s.indexOf("\n\n")==-1?s.size():s.indexOf("\n\n")));
         QStringList sl = s.split("\n");
         sl.removeAt(0);
-        sl.replaceInStrings(QRegExp(";(.*)"),"");
+        sl.replaceInStrings(QRegularExpression(";(.*)"),"");
         box->setLayout(new QVBoxLayout());
         for (int i=0; i<sl.size(); ++i) {
             QCheckBox* check = new QCheckBox(sl.at(i));

--- a/Source/GUI/Qt/editcustom.cpp
+++ b/Source/GUI/Qt/editcustom.cpp
@@ -90,7 +90,7 @@ void EditCustom::refreshDisplay() {
         s.truncate((s.indexOf("\n\n")==-1?s.size():s.indexOf("\n\n")));
         QStringList sl = s.split("\n");
         sl.removeAt(0);
-        sl.replaceInStrings(QRegExp(";(.*)"),"");
+        sl.replaceInStrings(QRegularExpression(";(.*)"),"");
         ui->comboBox->clear();
         for (int i=0; i<sl.size(); ++i) {
             ui->comboBox->addItem(sl.at(i),"%"+sl.at(i)+"%");


### PR DESCRIPTION
replaced QRegExp with QRegularExpression, it enables Qt 6 build (no any further changes are required), but breaks compatibility with Qt 4 (what is not big deal as for me)

in these particular cases it was enough jsut to replace, no changes to patterns are required