### PR TITLE
Qt GUI: fix Qt headers

### DIFF
--- a/Source/GUI/Qt/editsheet.cpp
+++ b/Source/GUI/Qt/editsheet.cpp
@@ -9,14 +9,14 @@
 #include "ui_editsheet.h"
 #include "sheet.h"
 #include "columneditsheet.h"
-#include "QHBoxLayout"
-#include "QLabel"
-#include "QLineEdit"
-#include "QSpinBox"
-#include "QPushButton"
-#include "QToolButton"
-#include "QSizePolicy"
-#include "QComboBox"
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QSpinBox>
+#include <QPushButton>
+#include <QToolButton>
+#include <QSizePolicy>
+#include <QComboBox>
 
 EditSheet::EditSheet(Sheet* s, Core* C, QWidget *parent) :
     QDialog(parent),


### PR DESCRIPTION
cosmetic change: replaced `""` with `<>` for Qt headers