### PR TITLE
Qt GUI: About dialog fixes

### DIFF
--- a/Source/GUI/Qt/about.cpp
+++ b/Source/GUI/Qt/about.cpp
@@ -24,6 +24,7 @@ About::About(const QString& version, QWidget *parent) :
     ui->donate->setVisible(false);
 #endif
 
+    ui->logoMail->setPixmap(QIcon(":/icon/aboutmail.svg").pixmap(ui->logoMail->maximumSize()));
     ui->aboutText->setText(ui->aboutText->text().replace("VERSION", version));
 }
 

--- a/Source/GUI/Qt/about.cpp
+++ b/Source/GUI/Qt/about.cpp
@@ -7,10 +7,11 @@
 #include "translate.h"
 #include "about.h"
 #include "ui_about.h"
+#include <QCoreApplication>
 #include <QDesktopServices>
 #include <QUrl>
 
-About::About(const QString& version, QWidget *parent) :
+About::About(QWidget *parent) :
     QDialog(parent),
     ui(new Ui::About)
 {
@@ -25,7 +26,7 @@ About::About(const QString& version, QWidget *parent) :
 #endif
 
     ui->logoMail->setPixmap(QIcon(":/icon/aboutmail.svg").pixmap(ui->logoMail->maximumSize()));
-    ui->aboutText->setText(ui->aboutText->text().replace("VERSION", version));
+    ui->aboutText->setText(ui->aboutText->text().arg(QCoreApplication::applicationVersion()));
 }
 
 About::~About()

--- a/Source/GUI/Qt/about.h
+++ b/Source/GUI/Qt/about.h
@@ -17,7 +17,7 @@ namespace Ui {
 class About : public QDialog {
     Q_OBJECT
 public:
-    About(const QString& version, QWidget *parent = 0);
+    About(QWidget *parent = 0);
     ~About();
 
 protected:

--- a/Source/GUI/Qt/about.ui
+++ b/Source/GUI/Qt/about.ui
@@ -106,9 +106,6 @@ Sound-only formats (AC3, DTS, AAC, AU, AIFF...)</string>
          <height>32</height>
         </size>
        </property>
-       <property name="pixmap">
-        <pixmap resource="../../Resource/Resources.qrc">:/icon/aboutmail.png</pixmap>
-       </property>
        <property name="scaledContents">
         <bool>true</bool>
        </property>

--- a/Source/GUI/Qt/about.ui
+++ b/Source/GUI/Qt/about.ui
@@ -32,9 +32,6 @@
          <property name="scaledContents">
           <bool>true</bool>
          </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-         </property>
         </widget>
        </item>
        <item>

--- a/Source/GUI/Qt/about.ui
+++ b/Source/GUI/Qt/about.ui
@@ -15,7 +15,7 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
      <item>
       <layout class="QVBoxLayout" name="verticalLayout_6">
        <item>
@@ -72,36 +72,10 @@ Sound-only formats (AC3, DTS, AAC, AU, AIFF...)</string>
        </property>
       </widget>
      </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
     </layout>
    </item>
    <item>
     <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item>
-    <spacer name="verticalSpacer_3">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>

--- a/Source/GUI/Qt/about.ui
+++ b/Source/GUI/Qt/about.ui
@@ -52,7 +52,7 @@
      <item>
       <widget class="QLabel" name="aboutText">
        <property name="text">
-        <string>MediaInfo vVERSION
+        <string>MediaInfo v%1
 Copyright (C) 2002-2020 Jerome Martinez
 
 Supply very detailled information

--- a/Source/GUI/Qt/about.ui
+++ b/Source/GUI/Qt/about.ui
@@ -182,6 +182,9 @@ Sound-only formats (AC3, DTS, AAC, AU, AIFF...)</string>
          <property name="text">
           <string>OK</string>
          </property>
+         <property name="default">
+          <bool>true</bool>
+         </property>
         </widget>
        </item>
       </layout>

--- a/Source/GUI/Qt/about.ui
+++ b/Source/GUI/Qt/about.ui
@@ -13,7 +13,7 @@
   <property name="windowTitle">
    <string/>
   </property>
-  <layout class="QVBoxLayout" name="verticalLayout">
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="0,1,0">
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,1">
      <item>

--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -1014,7 +1014,7 @@ void MainWindow::on_actionOpen_Folder_triggered()
 
 void MainWindow::on_actionAbout_triggered()
 {
-    About a(VERSION, this);
+    About a(this);
     a.exec();
 }
 

--- a/Source/Resource/Resources.qrc
+++ b/Source/Resource/Resources.qrc
@@ -9,6 +9,6 @@
         <file alias="prefs.svg">Image/Menu/K20/Options_Prefs.svg</file>
         <file alias="view.svg">Image/Menu/K20/View.svg</file>
         <file>Image/Menu/K20/View2.svg</file>
-        <file alias="aboutmail.png">Image/Menu/K20/Help_About.png</file>
+        <file alias="aboutmail.svg">Image/Menu/K20/Help_About.svg</file>
     </qresource>
 </RCC>


### PR DESCRIPTION
- simplified layout without visual changes
- better resize behavior - keep "about text" aligned to top
- use SVG icon for "info" icon (HighDPI support)
- "OK" button is default button
- get app version "in place" instead of passing it
- use format string for "about text" instead of "keyword + replace"

<img src="https://user-images.githubusercontent.com/947647/233514986-b8233e46-9777-419e-b93f-0a166dd3a30e.png" alt="Screenshot_20230420_082829" width=400 /><img src="https://user-images.githubusercontent.com/947647/233514992-b0e7886d-d388-4eef-9b18-02b899446ec8.png" alt="Screenshot_20230421_022932" width=400 />
