### PR TITLE
Use llvm bcc32c compiler for borland project

### DIFF
--- a/Project/BCB/GUI/MediaInfo_GUI.cbproj
+++ b/Project/BCB/GUI/MediaInfo_GUI.cbproj
@@ -41,7 +41,7 @@
 			<Base>true</Base>
 		</PropertyGroup>
 		<PropertyGroup Condition="'$(Base)'!=''">
-			<Defines>MEDIAINFO_DLL_RUNTIME;MEDIAINFODLL_NAME=L\"MediaInfo_i386.dll\";$(Defines)</Defines>
+			<Defines>MEDIAINFO_DLL_RUNTIME;MEDIAINFODLL_NAME=L"MediaInfo_i386.dll";$(Defines)</Defines>
 			<VerInfo_Keys>CompanyName=;FileDescription=;FileVersion=23.07.0.0;InternalName=;LegalCopyright=;LegalTrademarks=;OriginalFilename=;ProductName=;ProductVersion=;Comments=</VerInfo_Keys>
 			<Manifest_File>None</Manifest_File>
 			<VerInfo_IncludeVerInfo>true</VerInfo_IncludeVerInfo>
@@ -62,6 +62,7 @@
 			<IntermediateOutputDir>.\$(Platform)\$(Config)</IntermediateOutputDir>
 			<FinalOutputDir>.\$(Platform)\$(Config)</FinalOutputDir>
 			<BCC_wpar>false</BCC_wpar>
+			<BCC_UseClassicCompiler>false</BCC_UseClassicCompiler>
 			<BCC_OptimizeForSpeed>true</BCC_OptimizeForSpeed>
 			<BCC_ExtendedErrorInfo>true</BCC_ExtendedErrorInfo>
 			<ILINK_TranslatedLibraryPath>$(BDSLIB)\$(PLATFORM)\release\$(LANGDIR);$(ILINK_TranslatedLibraryPath)</ILINK_TranslatedLibraryPath>

--- a/Project/BCB/GUI/MediaInfo_GUI.cpp
+++ b/Project/BCB/GUI/MediaInfo_GUI.cpp
@@ -55,7 +55,7 @@ USEFORM("..\..\..\Source\GUI\VCL\GUI_Main.cpp", MainF);
 USEFORM("..\..\..\Source\GUI\VCL\GUI_About.cpp", AboutF);
 USEFORM("..\..\..\Source\GUI\VCL\GUI_Export.cpp", ExportF);
 //---------------------------------------------------------------------------
-WINAPI _tWinMain(HINSTANCE, HINSTANCE, LPTSTR, int)
+int WINAPI _tWinMain(HINSTANCE, HINSTANCE, LPTSTR, int)
 {
     try
     {

--- a/Source/GUI/VCL/GUI_Main.cpp
+++ b/Source/GUI/VCL/GUI_Main.cpp
@@ -927,10 +927,10 @@ void __fastcall TMainF::Refresh(TTabSheet *Page)
                 for (size_t Pos = 0; Pos < I->Count_Get(); Pos++)
                 {
                     Ztring Svg = I->Inform(Pos);
-                    size_t Pos = Svg.find(__T("<svg"));
-                    if (Pos != std::string::npos)
+                    size_t Pos2 = Svg.find(__T("<svg"));
+                    if (Pos2 != std::string::npos)
                         Svg = Svg.substr(Pos);
-                    S1 += (Pos ? __T("<br/>") : __T("")) + Svg;
+                    S1 += (Pos2 ? __T("<br/>") : __T("")) + Svg;
                 }
 
                 if (File::Exists(InstallFolder+__T("\\Plugin\\Graph\\Template.html")))

--- a/Source/GUI/VCL/GUI_Preferences_Sheet.cpp
+++ b/Source/GUI/VCL/GUI_Preferences_Sheet.cpp
@@ -154,12 +154,11 @@ void TPreferences_SheetF::Columns_Adapt()
             Column_Kind[Pos]->Style=Stdctrls::csDropDownList;
             Column_Kind[Pos]->OnChange=Column_Kind0Change;
             Column_Kind[Pos]->Parent=this;
-            Column_Kind[Pos]->Items->SetText(
-                                               L"General\r\n"
-                                                "Video\r\n"
-                                                "Audio\r\n"
-                                                "Text\r\n"
-                                                "Chapters\r\n");
+            Column_Kind[Pos]->Items->SetText(L"General\r\n"
+                                             L"Video\r\n"
+                                             L"Audio\r\n"
+                                             L"Text\r\n"
+                                             L"Chapters\r\n");
             Column_Kind[Pos]->ItemIndex=0;
             Column_Kind0Change(Column_Kind[Pos]);
         }
@@ -255,14 +254,14 @@ void __fastcall TPreferences_SheetF::OKClick(TObject *Sender)
         Z1+=Ztring::ToZtring(Pos);
         int I1=EditedSheet.Find(Z1);
         if (I1!=-1)
-            EditedSheet.erase(&EditedSheet(I1));
+            EditedSheet.erase(EditedSheet.begin()+I1);
     }
 
     //TODO: Purge blank lines, but why is there blank lines?
     while (EditedSheet.Find(__T(""))!=-1)
     {
         int I1=EditedSheet.Find(__T(""));
-        EditedSheet.erase(&EditedSheet(I1));
+        EditedSheet.erase(EditedSheet.begin()+I1);
     }
 
     //Save file


### PR DESCRIPTION
Drop support of classic bcc32 compiler dues to missing c++11 features

[snapshot](https://mediaarea.net/download/snapshots/binary/mediainfo-gui/20230731-3)