### PR TITLE
only refer to VS2022 projects in VS2022 build system. fixes #773

### DIFF
--- a/Project/MSVC2022/GUI/MediaInfo_GUI.vcxproj
+++ b/Project/MSVC2022/GUI/MediaInfo_GUI.vcxproj
@@ -181,7 +181,7 @@
     <ResourceCompile Include="MediaInfo_GUI.rc" />
   </ItemGroup>
   <ItemGroup>
-    <ProjectReference Include="..\..\..\..\MediaInfoLib\Project\MSVC2019\Library\MediaInfoLib.vcxproj">
+    <ProjectReference Include="..\..\..\..\MediaInfoLib\Project\MSVC2022\Library\MediaInfoLib.vcxproj">
       <Project>{20e0f8d6-213c-460b-b361-9c725cb375c7}</Project>
     </ProjectReference>
     <ProjectReference Include="..\..\..\..\wxWidgets\build\msw\wx_base.vcxproj">
@@ -196,7 +196,7 @@
     <ProjectReference Include="..\..\..\..\wxWidgets\build\msw\wx_wxpng.vcxproj">
       <Project>{8acc122a-ca6a-5aa6-9c97-9cdd2e533db0}</Project>
     </ProjectReference>
-    <ProjectReference Include="..\..\..\..\ZenLib\Project\MSVC2019\Library\ZenLib.vcxproj">
+    <ProjectReference Include="..\..\..\..\ZenLib\Project\MSVC2022\Library\ZenLib.vcxproj">
       <Project>{0da1da7d-f393-4e7c-a7ce-cb5c6a67bc94}</Project>
     </ProjectReference>
     <ProjectReference Include="..\..\..\..\zlib\contrib\vstudio\vc17\zlibstat.vcxproj">

--- a/Project/MSVC2022/MediaInfo_Qt/MediaInfo_Qt.vcxproj
+++ b/Project/MSVC2022/MediaInfo_Qt/MediaInfo_Qt.vcxproj
@@ -80,7 +80,7 @@
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>ZenLib.lib;QtCore.lib;QtGui.lib;QtXml.lib;QtNetwork.lib;qtsvg.lib;qsvgd.lib;qtmain.lib;winmm.lib;ws2_32.lib;imm32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\..\MediaInfoLib\Project\MSVC2019\Library\$(Platform)\$(Configuration);..\..\..\..\ZenLib\Project\MSVC2019\Library\$(Platform)\$(Configuration);..\..\..\..\zlib\projects\MSVC2019\$(Platform)\$(Configuration);../../../../Qt\lib\MSVC2019\$(Platform)\$(Configuration);../../../../Qt\plugins\imageformats;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\MediaInfoLib\Project\MSVC2022\Library\$(Platform)\$(Configuration);..\..\..\..\ZenLib\Project\MSVC2022\Library\$(Platform)\$(Configuration);..\..\..\..\zlib\projects\MSVC2022\$(Platform)\$(Configuration);../../../../Qt\lib\MSVC2022\$(Platform)\$(Configuration);../../../../Qt\plugins\imageformats;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <IgnoreSpecificDefaultLibraries>libcmt.lib;%(IgnoreSpecificDefaultLibraries)</IgnoreSpecificDefaultLibraries>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
@@ -104,7 +104,7 @@
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>ZenLib.lib;MediaInfo.lib;QtCored.lib;QtGuid.lib;QtXmld.lib;QtNetworkd.lib;qsvgd.lib;qtsvgd.lib;qtmaind.lib;winmm.lib;ws2_32.lib;imm32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\..\MediaInfoLib\Project\MSVC2019\Library\$(Platform)\$(Configuration);..\..\..\..\ZenLib\Project\MSVC2019\Library\$(Platform)\$(Configuration);..\..\..\..\zlib\projects\MSVC2019\$(Platform)\$(Configuration);../../../../Qt\lib\MSVC2019\$(Platform);../../../../Qt\plugins\imageformats;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\MediaInfoLib\Project\MSVC2022\Library\$(Platform)\$(Configuration);..\..\..\..\ZenLib\Project\MSVC2022\Library\$(Platform)\$(Configuration);..\..\..\..\zlib\projects\MSVC2022\$(Platform)\$(Configuration);../../../../Qt\lib\MSVC2022\$(Platform);../../../../Qt\plugins\imageformats;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <TargetMachine>MachineX64</TargetMachine>
@@ -124,7 +124,7 @@
     </ResourceCompile>
     <Link>
       <AdditionalDependencies>ZenLib.lib;QtCore.lib;QtGui.lib;QtXml.lib;qtsvg.lib;qsvg.lib;qtmain.lib;winmm.lib;ws2_32.lib;imm32.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\..\MediaInfoLib\Project\MSVC2019\Library\$(Platform)\$(Configuration);..\..\..\..\ZenLib\Project\MSVC2019\Library\$(Platform)\$(Configuration);..\..\..\..\zlib\projects\MSVC2019\$(Platform)\$(Configuration);../../../../Qt/lib/$(Platform)\$(Configuration);../../../../Qt\plugins\imageformats;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\MediaInfoLib\Project\MSVC2022\Library\$(Platform)\$(Configuration);..\..\..\..\ZenLib\Project\MSVC2022\Library\$(Platform)\$(Configuration);..\..\..\..\zlib\projects\MSVC2022\$(Platform)\$(Configuration);../../../../Qt/lib/$(Platform)\$(Configuration);../../../../Qt\plugins\imageformats;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
       <GenerateDebugInformation>true</GenerateDebugInformation>
       <SubSystem>Windows</SubSystem>
       <OptimizeReferences>true</OptimizeReferences>

--- a/Project/MSVC2022/MediaInfo_UWP/MediaInfo.vcxproj
+++ b/Project/MSVC2022/MediaInfo_UWP/MediaInfo.vcxproj
@@ -103,7 +103,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>MediaInfo-Static_UWP.lib;ZenLib_UWP.lib;zlibuwp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\..\MediaInfoLib\Project\MSVC2017\Arm\Debug;..\..\..\..\ZenLib\Project\MSVC2017\Arm\Debug;..\..\..\..\zlib\contrib\vstudio\vc15\Arm\Debug\zlibuwp;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\MediaInfoLib\Project\MSVC2022\Arm\Debug;..\..\..\..\ZenLib\Project\MSVC2022\Arm\Debug;..\..\..\..\zlib\contrib\vstudio\vc15\Arm\Debug\zlibuwp;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM'">
@@ -115,7 +115,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>MediaInfo-Static_UWP.lib;ZenLib_UWP.lib;zlibuwp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\..\MediaInfoLib\Project\MSVC2017\Arm\Release;..\..\..\..\ZenLib\Project\MSVC2017\Arm\Release;..\..\..\..\zlib\contrib\vstudio\vc15\Arm\Release\zlibuwp;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\MediaInfoLib\Project\MSVC2022\Arm\Release;..\..\..\..\ZenLib\Project\MSVC2022\Arm\Release;..\..\..\..\zlib\contrib\vstudio\vc15\Arm\Release\zlibuwp;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
@@ -127,7 +127,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>MediaInfo-Static_UWP.lib;ZenLib_UWP.lib;zlibuwp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\..\MediaInfoLib\Project\MSVC2017\Win32\Debug;..\..\..\..\ZenLib\Project\MSVC2017\Win32\Debug;..\..\..\..\zlib\contrib\vstudio\vc15\Debug\zlibuwp;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\MediaInfoLib\Project\MSVC2022\Win32\Debug;..\..\..\..\ZenLib\Project\MSVC2022\Win32\Debug;..\..\..\..\zlib\contrib\vstudio\vc15\Debug\zlibuwp;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -139,7 +139,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>MediaInfo-Static_UWP.lib;ZenLib_UWP.lib;zlibuwp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\..\MediaInfoLib\Project\MSVC2017\Win32\Release;..\..\..\..\ZenLib\Project\MSVC2017\Win32\Release;..\..\..\..\zlib\contrib\vstudio\vc15\Release\zlibuwp;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\MediaInfoLib\Project\MSVC2022\Win32\Release;..\..\..\..\ZenLib\Project\MSVC2022\Win32\Release;..\..\..\..\zlib\contrib\vstudio\vc15\Release\zlibuwp;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -151,7 +151,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>MediaInfo-Static_UWP.lib;ZenLib_UWP.lib;zlibuwp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\..\MediaInfoLib\Project\MSVC2017\x64\Debug;..\..\..\..\ZenLib\Project\MSVC2017\x64\Debug;..\..\..\..\zlib\contrib\vstudio\vc15\x64\Debug\zlibuwp;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\MediaInfoLib\Project\MSVC2022\x64\Debug;..\..\..\..\ZenLib\Project\MSVC2022\x64\Debug;..\..\..\..\zlib\contrib\vstudio\vc15\x64\Debug\zlibuwp;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -163,7 +163,7 @@
     </ClCompile>
     <Link>
       <AdditionalDependencies>MediaInfo-Static_UWP.lib;ZenLib_UWP.lib;zlibuwp.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <AdditionalLibraryDirectories>..\..\..\..\MediaInfoLib\Project\MSVC2017\x64\Release;..\..\..\..\ZenLib\Project\MSVC2017\x64\Release;..\..\..\..\zlib\contrib\vstudio\vc15\x64\Release\zlibuwp;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
+      <AdditionalLibraryDirectories>..\..\..\..\MediaInfoLib\Project\MSVC2022\x64\Release;..\..\..\..\ZenLib\Project\MSVC2022\x64\Release;..\..\..\..\zlib\contrib\vstudio\vc15\x64\Release\zlibuwp;%(AdditionalLibraryDirectories)</AdditionalLibraryDirectories>
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>


### PR DESCRIPTION
The MediaInfo MSVC2022 build system (solution and projects) were referring to the MSVC2017 and MSVC2019 build environments for dependant projects.
Some cross-contaminaton may still exist in MSVC2019 and MSVC2017 build environments - others should check these.