### PR TITLE
Windows GUI: Change monospaced font

### DIFF
--- a/Source/GUI/VCL/GUI_Main.cpp
+++ b/Source/GUI/VCL/GUI_Main.cpp
@@ -208,6 +208,15 @@ __fastcall TMainF::TMainF(TComponent* Owner)
     //Opt-out from styling dialogs and use native Windows dialogs for dark mode as well
     TStyleManager::SystemHooks = TStyleManager::SystemHooks -
                                  (TStyleManager::TSystemHooks() << TStyleManager::TSystemHook::shDialogs);
+
+    //Set monospaced font to Cascadia Mono if available on current system
+    if (Screen->Fonts->IndexOf("Cascadia Mono") != -1) {
+        TFont* monoFont = new TFont;
+        monoFont->Name = "Cascadia Mono";
+        monoFont->Size = 10;
+        Page_Text_Text->Font = monoFont;
+        Page_Custom_Text->Font = monoFont;
+    }
 }
 
 //***************************************************************************
@@ -2055,3 +2064,4 @@ void __fastcall TMainF::DestroyWnd()
         DragAcceptFiles(Handle, false);
     TForm::DestroyWnd();
 }
+


### PR DESCRIPTION
This patch makes MediaInfo use Cascadia Mono font for views that use monospaced font if Cascadia Mono is available on the system. Cascadia Mono is the default font for Windows Terminal. Most updated Windows systems with Windows Terminal installed will have this font.

Reason for this change is that the current font does not scale properly. Notice that it does not scale as linearly as Cascadia Mono. Cascadia Mono also has smoother edges and is easier to read especially on high DPI scaling.

Comparison @ 100%
![Screenshot 2024-05-22 201854](https://github.com/MediaArea/MediaInfo/assets/77721854/ddf072dc-3d47-4b7c-afc4-ff8b4c8acacb)

Comparison @ 150%
![Screenshot 2024-05-22 201854](https://github.com/MediaArea/MediaInfo/assets/77721854/d92d0d9f-14b9-4d24-a56f-de92399b1d70)

Comparison @ 200%
![Screenshot 2024-05-22 202101](https://github.com/MediaArea/MediaInfo/assets/77721854/aef88c6b-6710-4b73-a057-61f79fc3976b)