### PR TITLE
Windows GUI: Improve window size for high DPI

### DIFF
--- a/Source/GUI/VCL/GUI_Main.cpp
+++ b/Source/GUI/VCL/GUI_Main.cpp
@@ -227,16 +227,21 @@ __fastcall TMainF::TMainF(TComponent* Owner)
 void __fastcall TMainF::GUI_Configure()
 {
     //Hard coded
+    float DPIScale=static_cast<float>(GetSystemDpiForProcess(GetCurrentProcess()))/96;
+    float ScaledScreenWidth=Screen->Width/DPIScale;
+    float ScaledScreenHeight=Screen->Height/DPIScale;
     Width=500;
     Height=400;
-    if (Screen->Width>=1024)
+    if (ScaledScreenWidth>=1024)
         Width=700;
-    if (Screen->Width>=1280)
+    if (ScaledScreenWidth>=1280)
         Width=830;
-    if (Screen->Height>=768)
+    if (ScaledScreenHeight>=768)
         Height=500;
-    if (Screen->Height>=1024)
+    if (ScaledScreenHeight>=1024)
         Height=600;
+    Width*=DPIScale;
+    Height*=DPIScale;
     Left=(Screen->Width-Width)/2;
     Top=(Screen->Height-Height)/2;
 
@@ -2064,4 +2069,3 @@ void __fastcall TMainF::DestroyWnd()
         DragAcceptFiles(Handle, false);
     TForm::DestroyWnd();
 }
-


### PR DESCRIPTION
Take DPI scaling into account when setting window size. This should prevent cases where one ends up with a very small window filled with large icons and text when using a very high DPI display with very high DPI scaling.

Before and after this patch on a QHD display with 150% scaling for example
<img width="1076" alt="Screenshot 2024-05-23 005650" src="https://github.com/MediaArea/MediaInfo/assets/77721854/46dac5e0-17e4-494d-b258-3a5a2d678749">
The difference will be more with higher scaling.