### PR TITLE
Windows GUI: Change dialog for opening folders

### DIFF
--- a/Source/GUI/VCL/GUI_Main.cpp
+++ b/Source/GUI/VCL/GUI_Main.cpp
@@ -1190,15 +1190,15 @@ void __fastcall TMainF::M_File_Open_FileClick(TObject *Sender)
 //---------------------------------------------------------------------------
 void __fastcall TMainF::M_File_Open_FolderClick(TObject *Sender)
 {
-    Ztring S1=OpenFolder_Show(Application->Handle, __T("Select your directory"), __T("MediaInfo"));
+    if (!FolderOpenDialog1->Execute())
+        return;
 
-    if (S1!=__T(""))
-    {
+    if (TDirectory::GetFiles(FolderOpenDialog1->FileName).Length != 0) {
         // First we clear the list
         if (M_Options_CloseAllAuto->Checked)
             M_File_Close_AllClick(Sender);
 
-        I->Open(S1);
+        I->Open(GUI_Text(FolderOpenDialog1->FileName));
         Refresh();
     }
 }

--- a/Source/GUI/VCL/GUI_Main.dfm
+++ b/Source/GUI/VCL/GUI_Main.dfm
@@ -7313,6 +7313,13 @@ object MainF: TMainF
   object ApplicationEvents1: TApplicationEvents
     OnSettingChange = ApplicationEvents1OnSettingChange
     Left = 768
+    Top = 480
+  end
+  object FolderOpenDialog1: TFileOpenDialog
+    FavoriteLinks = <>
+    FileTypes = <>
+    Options = [fdoPickFolders]
+    Left = 768
     Top = 424
   end
 end

--- a/Source/GUI/VCL/GUI_Main.h
+++ b/Source/GUI/VCL/GUI_Main.h
@@ -28,6 +28,7 @@
 #include <ExtCtrls.hpp>
 #include <Buttons.hpp>
 #include <System.ImageList.hpp>
+#include <System.IOUtils.hpp>
 #include <Vcl.BaseImageCollection.hpp>
 #include <Vcl.ImageCollection.hpp>
 #include <Vcl.VirtualImageList.hpp>
@@ -229,6 +230,7 @@ __published:    // IDE-managed Components
     TVirtualImageList* Toolbar_Image;
     TMenuItem *M_Options_Darkmode;
     TApplicationEvents *ApplicationEvents1;
+    TFileOpenDialog *FolderOpenDialog1;
     void __fastcall FormResize(TObject *Sender);
     void __fastcall M_Help_AboutClick(TObject *Sender);
     void __fastcall M_Options_PreferencesClick(TObject *Sender);


### PR DESCRIPTION
Change the dialog for opening folders to the same dialog used for opening files on modern Windows systems. This is the dialog that other applications use for opening folders.