### PR TITLE
Windows GUI: Dialog fixes

### DIFF
--- a/Source/GUI/VCL/GUI_Main.cpp
+++ b/Source/GUI/VCL/GUI_Main.cpp
@@ -1190,7 +1190,7 @@ void __fastcall TMainF::M_File_Open_FileClick(TObject *Sender)
 //---------------------------------------------------------------------------
 void __fastcall TMainF::M_File_Open_FolderClick(TObject *Sender)
 {
-    if (!FolderOpenDialog1->Execute())
+    if (!FolderOpenDialog1->Execute(Handle))
         return;
 
     if (TDirectory::GetFiles(FolderOpenDialog1->FileName).Length != 0) {

--- a/Source/GUI/VCL/GUI_Main.dfm
+++ b/Source/GUI/VCL/GUI_Main.dfm
@@ -2576,6 +2576,7 @@ object MainF: TMainF
     Top = 256
   end
   object OpenDialog1: TOpenDialog
+    Options = [ofHideReadOnly, ofAllowMultiSelect, ofEnableSizing]
     Left = 768
     Top = 368
   end


### PR DESCRIPTION
Two commits:

1. Noticed that there is code to handle opening multiple files simultaneously but the Open File dialog doesn't allow selecting multiple files. It is now enabled and multiple files can be selected and opened simultaneously.

2. Minor fix to the positioning of the new Open Folder dialog. It now consistently opens at the same position near the corner of MediaInfo's main window.