### PR TITLE
Windows GUI: Use file folder and name as export default for single file

### DIFF
--- a/Source/GUI/VCL/GUI_Main.cpp
+++ b/Source/GUI/VCL/GUI_Main.cpp
@@ -1261,6 +1261,12 @@ void __fastcall TMainF::M_File_ExportClick(TObject *Sender)
             Name=Prefs->BaseFolder;
             Name.resize(Name.size()-1);
             Name=Name.substr(0, Name.rfind(__T("\\"))+1); //Folder of MediaInfo
+
+            //If only one file, use folder and filename of that file with added suffix
+            if (I->Count_Get()==1) {
+                Name=I->Get(0, Stream_General, 0, __T("CompleteName")).c_str();
+                Name.append(__T(".MediaInfo."));
+            }
         }
         else
             Name=GUI_Text(OpenDialog1->InitialDir);


### PR DESCRIPTION
When only a single file is open in MediaInfo, use that file's name and folder as the default when exporting instead of MediaInfo's AppData directory.

Not sure if can consider issue #741 as resolved since this PR is only for when there is a single file open.