### PR TITLE
Windows GUI: Dark mode for HTML view

### DIFF
--- a/Source/GUI/VCL/GUI_Main.h
+++ b/Source/GUI/VCL/GUI_Main.h
@@ -320,6 +320,7 @@ private:    // User declarations
     const UnicodeString LIGHT_MODE_STYLE = "Windows";               // Name of style for light mode;
     const UnicodeString DARK_MODE_STYLE = "Windows11 Modern Dark";  // Name of style for dark mode
     bool __fastcall WindowsDarkModeEnabled();
+    std::wstring __fastcall InjectDarkModeHTMLStyle(const wchar_t* HTMLDocument);
 public:        // User declarations
     MESSAGE void __fastcall HandleDropFiles (TMessage&);
     BEGIN_MESSAGE_MAP


### PR DESCRIPTION
Inject CSS style into the HTML to give it a dark mode.

![Screenshot 2024-05-31 171823](https://github.com/MediaArea/MediaInfo/assets/77721854/6dedd586-aeda-4dd8-938b-a2418e92d00c)

Let me know if you want to make changes to how it looks.