### PR TITLE
Windows GUI: Use older API for getting system DPI, update2

### DIFF
--- a/Project/BCB/GUI/MediaInfo_GUI.cbproj
+++ b/Project/BCB/GUI/MediaInfo_GUI.cbproj
@@ -111,6 +111,7 @@
 			<Manifest_File>$(BDS)\bin\default_app.manifest</Manifest_File>
 			<AppDPIAwarenessMode>PerMonitorV2</AppDPIAwarenessMode>
 			<Icon_MainIcon>..\..\..\Source\Resource\Image\MediaInfo.ico</Icon_MainIcon>
+			<ILINK_DelayLoadDll>user32.dll;$(ILINK_DelayLoadDll)</ILINK_DelayLoadDll>
 		</PropertyGroup>
 		<ItemGroup>
 			<LibFiles Condition="'$(Platform)'=='Win32'" Include="$(BDSLIB)\win32\release\wininet.lib">

--- a/Source/GUI/VCL/GUI_Main.cpp
+++ b/Source/GUI/VCL/GUI_Main.cpp
@@ -248,8 +248,8 @@ void __fastcall TMainF::GUI_Configure()
     osvi.dwOSVersionInfoSize = sizeof(OSVERSIONINFO);
     GetVersionEx(&osvi);
     int DPI;
-    if (osvi.dwMajorVersion >= 10 && (osvi.dwMajorVersion > 10 || osvi.dwMinorVersion > 0 || osvi.dwBuildNumber >= 17134))
-        DPI=GetDeviceCaps(GetDC(NULL), LOGPIXELSX); // GetSystemDpiForProcess(GetCurrentProcess());
+    if (osvi.dwMajorVersion >= 10 && (osvi.dwMajorVersion > 10 || osvi.dwMinorVersion > 0 || osvi.dwBuildNumber >= 14939))
+        DPI=GetDpiForWindow(WindowHandle);
     else
         DPI=GetDeviceCaps(GetDC(NULL), LOGPIXELSX);
     float DPIScale=static_cast<float>(DPI)/96;


### PR DESCRIPTION
Implement delayed loading of `user32.dll` and use `GetDpiForWindow`. Should work on Windows 7 to 11 now.

Tested on Windows 7 VM at 100% and 125%
Tested on Windows 11 PC at 100% and 150%

Nothing unexpected noticed, all seems fine.