### PR TITLE
Windows GUI: Implement theme preferences

### DIFF
--- a/Source/Common/Preferences.cpp
+++ b/Source/Common/Preferences.cpp
@@ -258,6 +258,7 @@ int Preferences::Config_Save()
     if (Config(__T("Donated")).empty()) Config(__T("Donated"))=__T("0");
     if (Config(__T("Donate_Display")).empty()) Config(__T("Donate_Display"))=__T("1");
     if (Config(__T("Sponsored")).empty()) Config(__T("Sponsored"))=__T("0");
+    if (Config(__T("Theme")).empty()) Config(__T("Theme"))=__T("0");
 
     HANDLE Temp=CreateFile((BaseFolder+__T("MediaInfo.cfg")).c_str(), GENERIC_WRITE, 0, NULL, CREATE_ALWAYS, 0, NULL);
     if (Temp==INVALID_HANDLE_VALUE)

--- a/Source/GUI/VCL/GUI_Main.dfm
+++ b/Source/GUI/VCL/GUI_Main.dfm
@@ -2339,9 +2339,24 @@ object MainF: TMainF
         Hint = 'Show Menu'
         OnClick = M_Options_ShowMenuClick
       end
-      object M_Options_Darkmode: TMenuItem
-        Caption = 'Dark mode'
-        OnClick = M_Options_DarkmodeClick
+      object M_Options_Theme: TMenuItem
+        Caption = 'Theme'
+        object M_Options_Theme_System: TMenuItem
+          Caption = 'System'
+          Checked = True
+          RadioItem = True
+          OnClick = M_Options_Theme_SystemClick
+        end
+        object M_Options_Theme_Light: TMenuItem
+          Caption = 'Light'
+          RadioItem = True
+          OnClick = M_Options_Theme_LightClick
+        end
+        object M_Options_Theme_Dark: TMenuItem
+          Caption = 'Dark'
+          RadioItem = True
+          OnClick = M_Options_Theme_DarkClick
+        end
       end
       object N5: TMenuItem
         Caption = '-'

--- a/Source/GUI/VCL/GUI_Main.h
+++ b/Source/GUI/VCL/GUI_Main.h
@@ -228,12 +228,15 @@ __published:    // IDE-managed Components
     TImageCollection* ImageCollection1;
     TVirtualImageList* Menu_Image;
     TVirtualImageList* Toolbar_Image;
-    TMenuItem *M_Options_Darkmode;
     TApplicationEvents *ApplicationEvents1;
     TFileOpenDialog *FolderOpenDialog1;
     TPanel *Page_Sheet_Panel1;
     TSplitter *Page_Sheet_Splitter1;
     TPanel *Page_Sheet_Panel2;
+    TMenuItem *M_Options_Theme;
+    TMenuItem *M_Options_Theme_System;
+    TMenuItem *M_Options_Theme_Light;
+    TMenuItem *M_Options_Theme_Dark;
     void __fastcall FormResize(TObject *Sender);
     void __fastcall M_Help_AboutClick(TObject *Sender);
     void __fastcall M_Options_PreferencesClick(TObject *Sender);
@@ -309,10 +312,12 @@ __published:    // IDE-managed Components
     void __fastcall M_View_NISO_Z39_87Click(TObject *Sender);
     void __fastcall M_View_Graph_SvgClick(TObject *Sender);
     void __fastcall M_Options_FullParsingClick(TObject *Sender);
-    void __fastcall M_Options_DarkmodeClick(TObject *Sender);
     void __fastcall ApplicationEvents1OnSettingChange(TObject *Sender, int Flag, const UnicodeString Section,
           int &Result);
     void __fastcall Page_Sheet_Splitter1Moved(TObject *Sender);
+    void __fastcall M_Options_Theme_SystemClick(TObject *Sender);
+    void __fastcall M_Options_Theme_LightClick(TObject *Sender);
+    void __fastcall M_Options_Theme_DarkClick(TObject *Sender);
 protected:
     virtual void __fastcall CreateWnd();
     virtual void __fastcall DestroyWnd();
@@ -321,6 +326,7 @@ private:    // User declarations
     const UnicodeString LIGHT_MODE_STYLE = "Windows";               // Name of style for light mode;
     const UnicodeString DARK_MODE_STYLE = "Windows11 Modern Dark";  // Name of style for dark mode
     bool __fastcall WindowsDarkModeEnabled();
+    void __fastcall ConfigTheme();
     std::wstring __fastcall InjectDarkModeHTMLStyle(const wchar_t* HTMLDocument);
 public:        // User declarations
     MESSAGE void __fastcall HandleDropFiles (TMessage&);


### PR DESCRIPTION
Enable user to save their preferences for application theme.

This is an implementation of the suggestion in https://github.com/MediaArea/MediaInfo/pull/836#issuecomment-2124305168 which I am only able to implement now after studying and figuring out how MediaInfo handle preferences.

![Screenshot 2024-06-18 170430](https://github.com/MediaArea/MediaInfo/assets/77721854/b949ebcb-76af-48ed-ba8a-f6afb689c762)

Fixed in latest force push:
>Still needs more testing and to fix this bug that occurs when MediaInfo tries to start in dark mode:
![Screenshot 2024-06-18 170453](https://github.com/MediaArea/MediaInfo/assets/77721854/e23a5542-fc8d-4b61-8a50-8c2689f9967f)
This is something we ran into in the initial dark mode implementation. It is supposedly caused by changing the theme during form show. Before this, we worked around by setting the theme in the form creation part. However, we need to find another place for it now because we need to read the preferences to set the theme and can only do so after the preferences are initialized and loaded.