### PR TITLE
Windows GUI: Improve app closing routine

### DIFF
--- a/Source/GUI/VCL/GUI_Main.cpp
+++ b/Source/GUI/VCL/GUI_Main.cpp
@@ -389,9 +389,17 @@ void __fastcall TMainF::FormShow(TObject *Sender)
 //---------------------------------------------------------------------------
 void __fastcall TMainF::FormClose(TObject *Sender, TCloseAction &Action)
 {
-    if (Page->ActivePage==Page_Sheet) //TODO : find WHY there is a crash without this...
-        ChangePage(Page_Easy);
+    //Delete temp HTML file on close
+    if (FileName_Temp!=__T(""))
+        File::Delete(FileName_Temp);
 
+    //The form is closed and all allocated memory for the form is freed.
+    Action = caFree;
+}
+
+//---------------------------------------------------------------------------
+void __fastcall TMainF::FormDestroy(TObject *Sender)
+{
     delete Prefs; Prefs=NULL;
     delete I; I=NULL;
 }
@@ -399,6 +407,10 @@ void __fastcall TMainF::FormClose(TObject *Sender, TCloseAction &Action)
 //---------------------------------------------------------------------------
 void __fastcall TMainF::FormResize(TObject *Sender)
 {
+    //If triggered on application close
+    if(Prefs==NULL)
+        return;
+
     //Main View
     Page->Left  =(ToolBar->Visible?ToolBar->Width:0)-2;
     Page->Width =ClientWidth-Page->Left+2;

--- a/Source/GUI/VCL/GUI_Main.dfm
+++ b/Source/GUI/VCL/GUI_Main.dfm
@@ -12,6 +12,7 @@ object MainF: TMainF
   Font.Style = []
   Menu = MainMenu
   OnClose = FormClose
+  OnDestroy = FormDestroy
   OnResize = FormResize
   OnShow = FormShow
   TextHeight = 13
@@ -2090,7 +2091,7 @@ object MainF: TMainF
   end
   object MainMenu: TMainMenu
     Images = Menu_Image
-    Left = 764
+    Left = 768
     Top = 28
     object M_File: TMenuItem
       Caption = 'File'

--- a/Source/GUI/VCL/GUI_Main.h
+++ b/Source/GUI/VCL/GUI_Main.h
@@ -270,6 +270,7 @@ __published:    // IDE-managed Components
     void __fastcall Page_Easy_FileChange(TObject *Sender);
     void __fastcall Page_Easy_DifferentViewClick(TObject *Sender);
     void __fastcall FormClose(TObject *Sender, TCloseAction &Action);
+    void __fastcall FormDestroy(TObject *Sender);
     void __fastcall Page_Sheet_Change(TObject *Sender);
     void __fastcall Page_Sheet_WebClick(TObject *Sender);
     void __fastcall Page_Easy_WebClick(TObject *Sender);


### PR DESCRIPTION
Clean-up temporary HTML file on exit and address cause of sheet view crashing on exit.

See https://github.com/MediaArea/MediaInfo/pull/871#issuecomment-2175843069 for more information.