### PR TITLE
Windows GUI: Use Edge WebView2 for HTML/Graph view

### DIFF
--- a/Release/Release_GUI_Windows_i386.bat
+++ b/Release/Release_GUI_Windows_i386.bat
@@ -29,6 +29,7 @@ copy BCB\GUI\MediaInfo_GUI.exe BCB\GUI\MediaInfo.exe
 copy  ..\Project\BCB\GUI\Win32\Release\MediaInfo_GUI.exe MediaInfo_GUI_Windows_i386\MediaInfo.exe
 xcopy  ..\..\MediaInfoLib\Project\MSVC2019\Win32\Release\MediaInfo.dll MediaInfo_GUI_Windows_i386\ /S
 xcopy ..\..\MediaInfoLib\Project\MSVC2019\Win32\Release\MediaInfo_InfoTip.dll MediaInfo_GUI_Windows_i386\ /S
+xcopy "C:\Program Files (x86)\Embarcadero\Studio\22.0\Redist\win32\WebView2Loader.dll" MediaInfo_GUI_Windows_i386\
 
 @rem --- Copying : Plugins ---
 xcopy ..\Source\Resource\Plugin\* MediaInfo_GUI_Windows_i386\Plugin\ /S

--- a/Release/Release_GUI_Windows_x64.bat
+++ b/Release/Release_GUI_Windows_x64.bat
@@ -26,6 +26,7 @@ mkdir MediaInfo_GUI_Windows_x64
 copy  ..\Project\BCB\GUI\Win64\Release\MediaInfo_GUI.exe MediaInfo_GUI_Windows_x64\MediaInfo.exe
 xcopy ..\..\MediaInfoLib\Project\MSVC2019\x64\Release\MediaInfo.dll MediaInfo_GUI_Windows_x64\ /S
 xcopy ..\..\MediaInfoLib\Project\MSVC2019\x64\Release\MediaInfo_InfoTip.dll MediaInfo_GUI_Windows_x64\ /S
+xcopy "C:\Program Files (x86)\Embarcadero\Studio\22.0\Redist\win64\WebView2Loader.dll" MediaInfo_GUI_Windows_x64\
 
 @rem --- Copying : Plugins ---
 xcopy ..\Source\Resource\Plugin\* MediaInfo_GUI_Windows_x64\Plugin\ /S

--- a/Source/GUI/VCL/GUI_Main.cpp
+++ b/Source/GUI/VCL/GUI_Main.cpp
@@ -164,6 +164,13 @@ std::wstring __fastcall TMainF::InjectHTMLStyle(const wchar_t* HTMLDocument) {
     std::wstring modifiedHTML(HTMLDocument);
     const wchar_t* StyleContent = L"";
 
+    //WebView2 Engine theme switching overrides
+    if (Prefs->Config(__T("Theme")).To_int32s()==1) //always light mode
+        StyleContent = L"<style>:root { --color-scheme: light; --border-color: navy; }</style>";
+    if (Prefs->Config(__T("Theme")).To_int32s()==2) //always dark mode
+        StyleContent = L"<style>:root { --color-scheme: dark; --border-color: blue; }</style>";
+    modifiedHTML = InsertText(modifiedHTML, L"</style>", StyleContent);
+
     //IE Engine workarounds
     if (TStyleManager::ActiveStyle == TStyleManager::Style[DARK_MODE_STYLE]) //app is currently in dark mode
         StyleContent = L"<meta http-equiv='X-UA-Compatible' content='IE=edge'><style>body { background-color: #121212; color: #FFFFFF; } table { border:1px solid blue; }</style>";
@@ -979,7 +986,7 @@ void __fastcall TMainF::Refresh(TTabSheet *Page)
         {
             Ztring TempA; TempA=Prefs->Translate(__T("At least one file"));
             Ztring Temp;
-            Temp+=L"<!DOCTYPE html><html><head></head><body>";
+            Temp+=L"<!DOCTYPE html><html><head><style>:root { color-scheme: var(--color-scheme, light); } @media (prefers-color-scheme: dark) { :root { --color-scheme: dark; } }</style></head><body>";
             Temp+=TempA.To_Unicode();
             Temp+=L"</body></html>";
             Temp=InjectHTMLStyle(Temp.c_str());
@@ -1105,7 +1112,7 @@ void __fastcall TMainF::Refresh(TTabSheet *Page)
                 S1 = State;
         }
 
-        if (S1.size()>1 && S1[0]=='<' && S1[1]=='h')
+        if (S1.size()>1 && ( !wcsncmp(S1.c_str(),L"<!DOCTYPE html>",15-1) || !wcsncmp(S1.c_str(),L"<html>",6-1) ))
         {
             //Supposing this is HTML
             Page_Custom_Text->Visible=false;
@@ -1119,6 +1126,7 @@ void __fastcall TMainF::Refresh(TTabSheet *Page)
                 FileName_Temp+=__T(".html");
             }
             F.Create(FileName_Temp, true);
+            S1=InjectHTMLStyle(S1.c_str());
             F.Write(S1);
             F.Close();
             //Navigate

--- a/Source/GUI/VCL/GUI_Main.cpp
+++ b/Source/GUI/VCL/GUI_Main.cpp
@@ -255,11 +255,18 @@ __fastcall TMainF::TMainF(TComponent* Owner)
     if (I == NULL)
         I = new MediaInfoList;
 
-    // Intitialize views for HTML output (prevent graphviz plugin from reading invalid metrics)
-    Page_Custom_HTML->Navigate(L"about:blank");
-
     //Load GUI preferences
     GUI_Configure();
+
+    //Set Edge WebView2 UDF directory environment variable
+    Ztring UserDataDir=Prefs->BaseFolder;
+    UserDataDir.resize(UserDataDir.size()-1);
+    UserDataDir=UserDataDir.substr(0, UserDataDir.rfind(__T("\\"))+1);
+    UserDataDir+=__T("WebView2");
+    SetEnvironmentVariable(__T("WEBVIEW2_USER_DATA_FOLDER"), UserDataDir.c_str());
+
+    // Intitialize views for HTML output (prevent graphviz plugin from reading invalid metrics)
+    Page_Custom_HTML->Navigate(L"about:blank");
 
     //File(s) in command line
     #ifdef UNICODE

--- a/Source/GUI/VCL/GUI_Main.dfm
+++ b/Source/GUI/VCL/GUI_Main.dfm
@@ -587,6 +587,7 @@ object MainF: TMainF
         Width = 300
         Height = 150
         TabOrder = 0
+        SelectedEngine = EdgeIfAvailable
         ControlData = {
           4C000000021F0000810F00000000000000000000000000000000000000000000
           000000004C000000000000000000000001000000E0D057007335CF11AE690800
@@ -627,6 +628,7 @@ object MainF: TMainF
         Width = 300
         Height = 369
         TabOrder = 1
+        SelectedEngine = EdgeIfAvailable
         ControlData = {
           4C000000021F0000232600000000000000000000000000000000000000000000
           000000004C000000000000000000000001000000E0D057007335CF11AE690800

--- a/Source/Install/MediaInfo_GUI_Windows.nsi
+++ b/Source/Install/MediaInfo_GUI_Windows.nsi
@@ -136,11 +136,13 @@ Section "SectionPrincipale" SEC01
     File "/oname=MediaInfo.exe" "..\..\Project\BCB\GUI\Win64\Release\MediaInfo_GUI.exe"
     File "..\..\..\MediaInfoLib\Project\MSVC2019\x64\Release\MediaInfo_InfoTip.dll"
     File "..\..\..\MediaInfoLib\Project\MSVC2019\x64\Release\MediaInfo.dll"
+    File "C:\Program Files (x86)\Embarcadero\Studio\22.0\Redist\win64\WebView2Loader.dll"
     File "$%BPATH%\Windows\libcurl\x64\Release\LIBCURL.DLL"
   ${Else}
     File "/oname=MediaInfo.exe" "..\..\Project\BCB\GUI\Win32\Release\MediaInfo_GUI.exe"
     File "..\..\..\MediaInfoLib\Project\MSVC2019\Win32\Release\MediaInfo_InfoTip.dll"
     File "..\..\..\MediaInfoLib\Project\MSVC2019\Win32\Release\MediaInfo.dll"
+    File "C:\Program Files (x86)\Embarcadero\Studio\22.0\Redist\win32\WebView2Loader.dll"
     File "$%BPATH%\Windows\libcurl\Win32\Release\LIBCURL.DLL"
   ${EndIf}
   File "$%BPATH%\Windows\libcurl\curl-ca-bundle.crt"
@@ -211,6 +213,7 @@ Section Uninstall
   !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\MediaInfo.exe"
   !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\MediaInfo.dll"
   !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\MediaInfo_i386.dll"
+  !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\WebView2Loader.dll"
   Delete "$INSTDIR\${PRODUCT_NAME}.url"
   Delete "$INSTDIR\uninst.exe"
   Delete "$INSTDIR\MediaInfo_InfoTip.dll"
@@ -237,6 +240,7 @@ Section Uninstall
   RMDir "$INSTDIR\Plugin\Sheet"
   RMDir "$INSTDIR\Plugin\Tree"
   RMDir "$INSTDIR\Plugin"
+  RMDir /r "$INSTDIR\WebView2"
   RMDir "$INSTDIR"
 
   SetRegView 64

--- a/Source/Install/MediaInfo_GUI_Windows_i386.nsi
+++ b/Source/Install/MediaInfo_GUI_Windows_i386.nsi
@@ -129,6 +129,7 @@ Section "SectionPrincipale" SEC01
   File "/oname=MediaInfo.exe" "..\..\Project\BCB\GUI\Win32\Release\MediaInfo_GUI.exe"
   File "..\..\..\MediaInfoLib\Project\MSVC2019\Win32\Release\MediaInfo_InfoTip.dll"
   File "..\..\..\MediaInfoLib\Project\MSVC2019\Win32\Release\MediaInfo.dll"
+  File "C:\Program Files (x86)\Embarcadero\Studio\22.0\Redist\win32\WebView2Loader.dll"
   File "$%BPATH%\Windows\libcurl\Win32\Release\LIBCURL.DLL"
   File "$%BPATH%\Windows\libcurl\curl-ca-bundle.crt"
   File "/oname=History.txt" "..\..\History_GUI.txt"
@@ -197,6 +198,7 @@ Section Uninstall
   !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\MediaInfo.exe"
   !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\MediaInfo.dll"
   !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\MediaInfo_i386.dll"
+  !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\WebView2Loader.dll"
   Delete "$INSTDIR\${PRODUCT_NAME}.url"
   Delete "$INSTDIR\uninst.exe"
   Delete "$INSTDIR\MediaInfo_InfoTip.dll"
@@ -223,6 +225,7 @@ Section Uninstall
   RMDir "$INSTDIR\Plugin\Sheet"
   RMDir "$INSTDIR\Plugin\Tree"
   RMDir "$INSTDIR\Plugin"
+  RMDir /r "$INSTDIR\WebView2"
   RMDir "$INSTDIR"
 
   DeleteRegKey HKLM "${PRODUCT_REGISTRY}"

--- a/Source/Install/MediaInfo_GUI_Windows_x64.nsi
+++ b/Source/Install/MediaInfo_GUI_Windows_x64.nsi
@@ -138,6 +138,7 @@ Section "SectionPrincipale" SEC01
   File "/oname=MediaInfo.exe" "..\..\Project\BCB\GUI\Win64\Release\MediaInfo_GUI.exe"
   File "..\..\..\MediaInfoLib\Project\MSVC2019\x64\Release\MediaInfo_InfoTip.dll"
   File "..\..\..\MediaInfoLib\Project\MSVC2019\x64\Release\MediaInfo.dll"
+  File "C:\Program Files (x86)\Embarcadero\Studio\22.0\Redist\win64\WebView2Loader.dll"
   File "$%BPATH%\Windows\libcurl\x64\Release\LIBCURL.DLL"
   File "$%BPATH%\Windows\libcurl\curl-ca-bundle.crt"
   File "/oname=History.txt" "..\..\History_GUI.txt"
@@ -207,6 +208,7 @@ Section Uninstall
   !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\MediaInfo.exe"
   !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\MediaInfo.dll"
   !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\MediaInfo_i386.dll"
+  !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\WebView2Loader.dll"
   Delete "$INSTDIR\${PRODUCT_NAME}.url"
   Delete "$INSTDIR\uninst.exe"
   Delete "$INSTDIR\MediaInfo_InfoTip.dll"
@@ -233,6 +235,7 @@ Section Uninstall
   RMDir "$INSTDIR\Plugin\Sheet"
   RMDir "$INSTDIR\Plugin\Tree"
   RMDir "$INSTDIR\Plugin"
+  RMDir /r "$INSTDIR\WebView2"
   RMDir "$INSTDIR"
 
   SetRegView 64


### PR DESCRIPTION
Use Edge WebView2 for HTML and Graph view when available else fallback to IE.

This should work on Windows 7 to 11 both with and without Edge WebView2 Runtime installed.

Additional changes beyond this PR that are required to get WebView2 working:
- Install `EdgeView2 SDK 1.0.1054.31 by Microsoft` or `EdgeView2 SDK 1.0.2739.1 by Microsoft` from `GetIt Package Manager` in `C++Builder`.

Commits details:
- Use Edge Webview2 for HTML and Graph views
  - Set TWebBrowser to prefer Edge WebView2
  - Code additions to set the UDF directory. This ensures the WebView2 UDF will always be beside the Plugin folder that contains MediaInfo's config.
- Enable WebView2 native dark mode
  - Code additions to override theme (WebView2 already automatically follows system theme) by injecting CSS
  - Code changes to enable using the new `Template.html` for Graph view that enables dark mode
    - I will submit `Template.html` once the repo for it is up since it is understood that it will be.
      (EDIT: Let's just put the file here: [Template.zip](https://github.com/user-attachments/files/16467258/Template.zip))
    - Even without updated template, it should still work properly, just without dark mode support.
- Bundle WebView2Loader.dll
  - This DLL is required for WebView2 to work and will be available after installing the package mentioned above 
  - Changes to `.nsi` to include `WebView2Loader.dll` in install directory on install and remove it on uninstall.
    - Also removes WebView2 UDF folder if present in the install directory. This folder should be in `%APPDATA%\MediaInfo` in typical installations (with read-only install dir) and will be left there on uninstall along with the Plugin folder.
  - Changes to `.bat` files to include `WebView2Loader.dll` in the 7z archives.

Additional notes:
- This change actually unintentionally enables dark scrollbars for IE engine in dark theme too.
- To test engine fallback, it is not necessary to uninstall WebView2 runtime. Just rename `WebView2Loader.dll`.