### PR TITLE
Qt GUI Improvements

### DIFF
--- a/Project/QMake/GUI/MediaInfoQt.pro
+++ b/Project/QMake/GUI/MediaInfoQt.pro
@@ -188,7 +188,7 @@ win32 {
         }
     }
     QMAKE_CXXFLAGS += /guard:cf
-    QMAKE_LFLAGS += /guard:cf
+    QMAKE_LFLAGS += /guard:cf /CETCOMPAT
 }
 
 INCLUDEPATH += _Automated \

--- a/Project/QMake/GUI/MediaInfoQt.pro
+++ b/Project/QMake/GUI/MediaInfoQt.pro
@@ -185,6 +185,8 @@ win32 {
             } else {
                 error("zlib not found on system")
             }
+            QMAKE_CXXFLAGS += /guard:cf
+            QMAKE_LFLAGS += /guard:cf
         }
     }
 }

--- a/Project/QMake/GUI/MediaInfoQt.pro
+++ b/Project/QMake/GUI/MediaInfoQt.pro
@@ -73,21 +73,21 @@ win32 {
         INCLUDEPATH+=$$[QT_INSTALL_PREFIX]/include/QtCore/$$[QT_VERSION]
 
         contains(QT_ARCH, ARM) {
-            exists(../../../../MediaInfoLib/Project/MSVC2017/Arm/Release/MediaInfo-Static_UWP.lib) {
+            exists(../../../../MediaInfoLib/Project/MSVC2022/Arm/Release/MediaInfo-Static_UWP.lib) {
                 INCLUDEPATH += ../../../../MediaInfoLib/Source
-                LIBS += ../../../../MediaInfoLib/Project/MSVC2017/Arm/Release/MediaInfo-Static_UWP.lib
+                LIBS += ../../../../MediaInfoLib/Project/MSVC2022/Arm/Release/MediaInfo-Static_UWP.lib
             } else {
                 error("libmediainfo not found on system")
             }
 
-            exists(../../../../ZenLib/Project/MSVC2017/Arm/Release/ZenLib_UWP.lib) {
+            exists(../../../../ZenLib/Project/MSVC2022/Arm/Release/ZenLib_UWP.lib) {
                 INCLUDEPATH += ../../../../ZenLib/Source
-                LIBS += ../../../../ZenLib/Project/MSVC2017/Arm/Release/ZenLib_UWP.lib
+                LIBS += ../../../../ZenLib/Project/MSVC2022/Arm/Release/ZenLib_UWP.lib
             } else {
                 error("libzen not found on system")
             }
 
-            exists(../../../../zlib/contrib/vstudio/vc15/Arm/Release/zlibuwp.lib) {
+            exists(../../../../zlib/contrib/vstudio/vc17/Arm/Release/zlibuwp.lib) {
                 INCLUDEPATH += ../../../../zlib
                 LIBS += ../../../../zlib/contrib/vstudio/Arm/x86/Release/zlibuwp.lib
             } else {
@@ -96,69 +96,69 @@ win32 {
         }
 
         contains(QT_ARCH, i386) {
-            exists(../../../../MediaInfoLib/Project/MSVC2017/Win32/Release/MediaInfo-Static_UWP.lib) {
+            exists(../../../../MediaInfoLib/Project/MSVC2022/Win32/Release/MediaInfo-Static_UWP.lib) {
                 INCLUDEPATH += ../../../../MediaInfoLib/Source
-                LIBS += ../../../../MediaInfoLib/Project/MSVC2017/Win32/Release/MediaInfo-Static_UWP.lib
+                LIBS += ../../../../MediaInfoLib/Project/MSVC2022/Win32/Release/MediaInfo-Static_UWP.lib
             } else {
                 error("libmediainfo not found on system")
             }
 
-            exists(../../../../ZenLib/Project/MSVC2017/Win32/Release/ZenLib_UWP.lib) {
+            exists(../../../../ZenLib/Project/MSVC2022/Win32/Release/ZenLib_UWP.lib) {
                 INCLUDEPATH += ../../../../ZenLib/Source
-                LIBS += ../../../../ZenLib/Project/MSVC2017/Win32/Release/ZenLib_UWP.lib
+                LIBS += ../../../../ZenLib/Project/MSVC2022/Win32/Release/ZenLib_UWP.lib
             } else {
                 error("libzen not found on system")
             }
 
-            exists(../../../../zlib/contrib/vstudio/vc15/Release/zlibuwp/zlibuwp.lib) {
+            exists(../../../../zlib/contrib/vstudio/vc17/Release/zlibuwp/zlibuwp.lib) {
                 INCLUDEPATH += ../../../../zlib
-                LIBS += ../../../../zlib/contrib/vstudio/vc15/Release/zlibuwp/zlibuwp.lib
+                LIBS += ../../../../zlib/contrib/vstudio/vc17/Release/zlibuwp/zlibuwp.lib
             } else {
                 error("zlib not found on system")
             }
         }
 
         contains(QT_ARCH, x86_64) {
-            exists(../../../../MediaInfoLib/Project/MSVC2017/x64/Release/MediaInfo-Static_UWP.lib) {
+            exists(../../../../MediaInfoLib/Project/MSVC2022/x64/Release/MediaInfo-Static_UWP.lib) {
                 INCLUDEPATH += ../../../../MediaInfoLib/Source
-                LIBS += ../../../../MediaInfoLib/Project/MSVC2017/x64/Release/MediaInfo-Static_UWP.lib
+                LIBS += ../../../../MediaInfoLib/Project/MSVC2022/x64/Release/MediaInfo-Static_UWP.lib
             } else {
                 error("libmediainfo not found on system")
             }
 
-            exists(../../../../ZenLib/Project/MSVC2017/x64/Release/ZenLib_UWP.lib) {
+            exists(../../../../ZenLib/Project/MSVC2022/x64/Release/ZenLib_UWP.lib) {
                 INCLUDEPATH += ../../../../ZenLib/Source
-                LIBS += ../../../../ZenLib/Project/MSVC2017/x64/Release/ZenLib_UWP.lib
+                LIBS += ../../../../ZenLib/Project/MSVC2022/x64/Release/ZenLib_UWP.lib
             } else {
                 error("libzen not found on system")
             }
 
-            exists(../../../../zlib/contrib/vstudio/vc15/x64/Release/zlibuwp/zlibuwp.lib) {
+            exists(../../../../zlib/contrib/vstudio/vc17/x64/Release/zlibuwp/zlibuwp.lib) {
                 INCLUDEPATH += ../../../../zlib
-                LIBS += ../../../../zlib/contrib/vstudio/vc15/x64/Release/zlibuwp/zlibuwp.lib
+                LIBS += ../../../../zlib/contrib/vstudio/vc17/x64/Release/zlibuwp/zlibuwp.lib
             } else {
                 error("zlib not found on system")
             }
         }
     } else {
         contains(QT_ARCH, i386) {
-            exists(../../../../MediaInfoLib/Project/MSVC2017/Win32/Release/MediaInfo-Static.lib) {
+            exists(../../../../MediaInfoLib/Project/MSVC2022/Win32/Release/MediaInfo-Static.lib) {
                 INCLUDEPATH += ../../../../MediaInfoLib/Source
-                LIBS += ../../../../MediaInfoLib/Project/MSVC2017/Win32/Release/MediaInfo-Static.lib
+                LIBS += $$PWD/../../../../MediaInfoLib/Project/MSVC2022/Win32/Release/MediaInfo-Static.lib
             } else {
                 error("libmediainfo not found on system")
             }
 
-            exists(../../../../ZenLib/Project/MSVC2017/Win32/Release/ZenLib.lib) {
+            exists(../../../../ZenLib/Project/MSVC2022/Win32/Release/ZenLib.lib) {
                 INCLUDEPATH += ../../../../ZenLib/Source
-                LIBS += ../../../../ZenLib/Project/MSVC2017/Win32/Release/ZenLib.lib
+                LIBS += $$PWD/../../../../ZenLib/Project/MSVC2022/Win32/Release/ZenLib.lib
             } else {
                 error("libzen not found on system")
             }
 
-            exists(../../../../zlib/contrib/vstudio/vc15/x86/ZlibStatReleaseWithoutAsm/zlibstat.lib) {
+            exists(../../../../zlib/contrib/vstudio/vc17/x86/ZlibStatReleaseWithoutAsm/zlibstat.lib) {
                 INCLUDEPATH += ../../../../zlib
-                LIBS += ../../../../zlib/contrib/vstudio/vc15/x86/ZlibStatReleaseWithoutAsm/zlibstat.lib
+                LIBS += $$PWD/../../../../zlib/contrib/vstudio/vc17/x86/ZlibStatReleaseWithoutAsm/zlibstat.lib
             } else {
                 error("zlib not found on system")
             }
@@ -185,10 +185,10 @@ win32 {
             } else {
                 error("zlib not found on system")
             }
-            QMAKE_CXXFLAGS += /guard:cf
-            QMAKE_LFLAGS += /guard:cf
         }
     }
+    QMAKE_CXXFLAGS += /guard:cf
+    QMAKE_LFLAGS += /guard:cf
 }
 
 INCLUDEPATH += _Automated \

--- a/Project/QMake/GUI/MediaInfoQt.pro
+++ b/Project/QMake/GUI/MediaInfoQt.pro
@@ -165,23 +165,23 @@ win32 {
         }
 
         contains(QT_ARCH, x86_64) {
-            exists(../../../../MediaInfoLib/Project/MSVC2017/x64/Release/MediaInfo-Static.lib) {
+            exists(../../../../MediaInfoLib/Project/MSVC2022/x64/Release/MediaInfo-Static.lib) {
                 INCLUDEPATH += ../../../../MediaInfoLib/Source
-                LIBS += ../../../../MediaInfoLib/Project/MSVC2017/x64/Release/MediaInfo-Static.lib
+                LIBS += $$PWD/../../../../MediaInfoLib/Project/MSVC2022/x64/Release/MediaInfo-Static.lib
             } else {
                 error("libmediainfo not found on system")
             }
 
-            exists(../../../../ZenLib/Project/MSVC2017/x64/Release/ZenLib.lib) {
+            exists(../../../../ZenLib/Project/MSVC2022/x64/Release/ZenLib.lib) {
                 INCLUDEPATH += ../../../../ZenLib/Source
-                LIBS += ../../../../ZenLib/Project/MSVC2017/x64/Release/ZenLib.lib
+                LIBS += $$PWD/../../../../ZenLib/Project/MSVC2022/x64/Release/ZenLib.lib
             } else {
                 error("libzen not found on system")
             }
 
-            exists(../../../../zlib/contrib/vstudio/vc15/x64/ZlibStatReleaseWithoutAsm/zlibstat.lib) {
+            exists(../../../../zlib/contrib/vstudio/vc17/x64/ZlibStatReleaseWithoutAsm/zlibstat.lib) {
                 INCLUDEPATH += ../../../../zlib
-                LIBS += ../../../../zlib/contrib/vstudio/vc15/x64/ZlibStatReleaseWithoutAsm/zlibstat.lib
+                LIBS += $$PWD/../../../../zlib/contrib/vstudio/vc17/x64/ZlibStatReleaseWithoutAsm/zlibstat.lib
             } else {
                 error("zlib not found on system")
             }

--- a/Source/GUI/Qt/easyviewwidget.cpp
+++ b/Source/GUI/Qt/easyviewwidget.cpp
@@ -127,10 +127,6 @@ QGroupBox* EasyViewWidget::createBox(stream_t StreamKind, int StreamPos) {
         return NULL;
 
     QGroupBox* box = new QGroupBox(Title_Get(StreamKind));
-    if(StreamKind==Stream_General)
-        box->setSizePolicy(QSizePolicy::Minimum,QSizePolicy::Minimum);
-    else
-        box->setSizePolicy(QSizePolicy::Minimum,QSizePolicy::Maximum);
     QHBoxLayout* boxLayout = new QHBoxLayout();
     box->setLayout(boxLayout);
     QLabel* label = new QLabel(Temp);
@@ -143,6 +139,7 @@ QGroupBox* EasyViewWidget::createBox(stream_t StreamKind, int StreamPos) {
         boxLayout->addWidget(labelTags);
     }
 
+    box->setSizePolicy(QSizePolicy::Minimum,QSizePolicy::Minimum);
     return box;
 }
 

--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -185,8 +185,13 @@ MainWindow::MainWindow(QStringList filesnames, int viewasked, QWidget *parent) :
 #endif
 
     //tests
+#if QT_VERSION > QT_VERSION_CHECK(6, 7, 0)
+    ui->actionQuit->setIcon(QIcon::fromTheme(QIcon::ThemeIcon::WindowClose));
+    ui->actionClose_All->setIcon(QIcon::fromTheme(QIcon::ThemeIcon::WindowClose));
+#else
     ui->actionQuit->setIcon(style()->standardIcon(QStyle::SP_DialogCloseButton));
     ui->actionClose_All->setIcon(style()->standardIcon(QStyle::SP_DialogCloseButton));
+#endif
     ui->actionOpen->setIcon(QIcon(":/icon/openfile.svg"));
     ui->actionOpen_Folder->setIcon(QIcon(":/icon/opendir.svg"));
     ui->actionAbout->setIcon(QIcon(":/icon/about.svg"));

--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -198,23 +198,23 @@ MainWindow::MainWindow(QStringList filesnames, int viewasked, QWidget *parent) :
     ui->actionExport->setIcon(QIcon(":/icon/export.svg"));
 
     menuView = new QMenu();
-   QActionGroup* menuItemGroup = new QActionGroup(this);
-   for(int v=VIEW_EASY;v<NB_VIEW;v++) {
-       QAction* action = new QAction(nameView((ViewMode)v), menuItemGroup);
-       action->setCheckable(true);
-       if(view==v)
-           action->setChecked(true);
-       action->setProperty("view",v);
-       ui->menuView->addAction(action);
-       menuView->addAction(action);
-   }
-   connect(menuItemGroup,SIGNAL(triggered(QAction*)),this,SLOT(actionView_toggled(QAction*)));
+    QActionGroup* menuItemGroup = new QActionGroup(this);
+    for(int v=VIEW_EASY;v<NB_VIEW;v++) {
+        QAction* action = new QAction(nameView((ViewMode)v), menuItemGroup);
+        action->setCheckable(true);
+        if(view==v)
+            action->setChecked(true);
+        action->setProperty("view",v);
+        ui->menuView->addAction(action);
+        menuView->addAction(action);
+    }
+    connect(menuItemGroup,SIGNAL(triggered(QAction*)),this,SLOT(actionView_toggled(QAction*)));
 
-   buttonView = new QToolButton();
-   buttonView->setText("view");
-   buttonView->setIcon(QIcon(":/icon/view.svg"));
-   connect(buttonView, SIGNAL(clicked()), this, SLOT(buttonViewClicked()));
-   ui->toolBar->addWidget(buttonView);
+    buttonView = new QToolButton();
+    buttonView->setText("view");
+    buttonView->setIcon(QIcon(":/icon/view.svg"));
+    connect(buttonView, SIGNAL(clicked()), this, SLOT(buttonViewClicked()));
+    ui->toolBar->addWidget(buttonView);
 
     ui->toolBar->setContextMenuPolicy(Qt::CustomContextMenu);
     connect(ui->toolBar,SIGNAL(customContextMenuRequested(QPoint)),this,SLOT(toolBarOptions(QPoint)));
@@ -273,33 +273,33 @@ void MainWindow::checkForNewVersion() {
     reply = qnam.get(QNetworkRequest(url));
     qDebug() << "downloading " << url.toString();
 
-     connect(reply, SIGNAL(finished()), this, SLOT(httpFinished()));
-     connect(reply, SIGNAL(readyRead()), this, SLOT(httpReadyRead()));
+    connect(reply, SIGNAL(finished()), this, SLOT(httpFinished()));
+    connect(reply, SIGNAL(readyRead()), this, SLOT(httpReadyRead()));
 
 }
 
 void MainWindow::httpFinished()
 {
-         if (reply->error()) {
-             qDebug() << "Download failed";
-         } else {
-             qDebug() << "Downloaded file to temp string.";
-         }
+    if (reply->error()) {
+        qDebug() << "Download failed";
+    } else {
+        qDebug() << "Downloaded file to temp string.";
+    }
 
-         ZtringListList X;
-         X.Write(file.toStdString().c_str());
-         if (isNewer(wstring2QString(X("NewVersion")),QString(VERSION))) {
-             qDebug() << "New version is available.";
-             qDebug() << "latest is " << wstring2QString(X("NewVersion")).toStdString().c_str();
-             ui->menuBar->addAction(Tr("Update to new version"),this,SLOT(updateToNewVersion()));
-         } else {
-             qDebug() << "No new version available.";
-             qDebug() << "latest is " << wstring2QString(X("NewVersion")).toStdString().c_str();
-         }
+    ZtringListList X;
+    X.Write(file.toStdString().c_str());
+    if (isNewer(wstring2QString(X("NewVersion")),QString(VERSION))) {
+        qDebug() << "New version is available.";
+        qDebug() << "latest is " << wstring2QString(X("NewVersion")).toStdString().c_str();
+        ui->menuBar->addAction(Tr("Update to new version"),this,SLOT(updateToNewVersion()));
+    } else {
+        qDebug() << "No new version available.";
+        qDebug() << "latest is " << wstring2QString(X("NewVersion")).toStdString().c_str();
+    }
 
-         reply->deleteLater();
-         reply = 0;
-         file = "";
+    reply->deleteLater();
+    reply = 0;
+    file = "";
 }
 
 void MainWindow::updateToNewVersion() {
@@ -308,7 +308,7 @@ void MainWindow::updateToNewVersion() {
 
 void MainWindow::httpReadyRead()
 {
-        file.append(reply->readAll());
+    file.append(reply->readAll());
 }
 #endif //NEW_VERSION
 
@@ -779,7 +779,7 @@ QTreeWidget* MainWindow::showTreeView(bool completeDisplay) {
                             B=B.mid(level);
 
                         if (level==tree.count() && tree.back()->childCount())
-                           tree.append(tree.back()->child(tree.back()->childCount()-1));
+                            tree.append(tree.back()->child(tree.back()->childCount()-1));
                         else if (level<tree.count()-1)
                             tree.resize(level+1);
 
@@ -1011,7 +1011,7 @@ void MainWindow::on_actionOpen_Folder_triggered()
 #endif
     openDir(dirName);
 
-   refreshDisplay();
+    refreshDisplay();
 }
 
 void MainWindow::on_actionAbout_triggered()

--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -17,8 +17,6 @@
 #include "configtreetext.h"
 #include "custom.h"
 
-#include <iostream>
-#include <iomanip>
 #include <QDropEvent>
 #include <QFileDialog>
 #include <QMessageBox>

--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -488,7 +488,8 @@ void MainWindow::openDir(QString dirName) {
 }
 
 void MainWindow::refreshDisplay() {
-    QFont font("Mono");
+    QStringList fonts = { "Cascadia Mono", "Mono" };
+    QFont font(fonts);
     font.setStyleHint(QFont::TypeWriter);
 
     ui->actionAdapt_columns_to_content->setVisible(false);

--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -185,13 +185,12 @@ MainWindow::MainWindow(QStringList filesnames, int viewasked, QWidget *parent) :
 #endif
 
     //tests
-    ui->actionQuit->setIcon(QIcon::fromTheme("application-exit"));
-    ui->actionClose_All->setIcon(QIcon::fromTheme("dialog-close"));
-    ui->actionOpen->setIcon(QIcon::fromTheme("document-open"));
-    ui->actionOpen_Folder->setIcon(QIcon::fromTheme("document-open-folder"));
-    ui->actionAbout->setIcon(QIcon::fromTheme("help-about"));
-    ui->actionExport->setIcon(QIcon::fromTheme("document-export"));
-    ui->actionPreferences->setIcon(QIcon::fromTheme("configure"));
+    ui->actionQuit->setIcon(style()->standardIcon(QStyle::SP_DialogCloseButton));
+    ui->actionClose_All->setIcon(style()->standardIcon(QStyle::SP_DialogCloseButton));
+    ui->actionOpen->setIcon(QIcon(":/icon/openfile.svg"));
+    ui->actionOpen_Folder->setIcon(QIcon(":/icon/opendir.svg"));
+    ui->actionAbout->setIcon(QIcon(":/icon/about.svg"));
+    ui->actionExport->setIcon(QIcon(":/icon/export.svg"));
 
     menuView = new QMenu();
    QActionGroup* menuItemGroup = new QActionGroup(this);
@@ -208,7 +207,7 @@ MainWindow::MainWindow(QStringList filesnames, int viewasked, QWidget *parent) :
 
    buttonView = new QToolButton();
    buttonView->setText("view");
-   buttonView->setIcon(QIcon::fromTheme("view-list-details"));
+   buttonView->setIcon(QIcon(":/icon/view.svg"));
    connect(buttonView, SIGNAL(clicked()), this, SLOT(buttonViewClicked()));
    ui->toolBar->addWidget(buttonView);
 

--- a/Source/GUI/Qt/mainwindow.ui
+++ b/Source/GUI/Qt/mainwindow.ui
@@ -51,7 +51,7 @@
      <x>0</x>
      <y>0</y>
      <width>600</width>
-     <height>25</height>
+     <height>22</height>
     </rect>
    </property>
    <widget class="QMenu" name="menuView">
@@ -99,6 +99,9 @@
    </property>
    <property name="windowTitle">
     <string>toolBar</string>
+   </property>
+   <property name="movable">
+    <bool>false</bool>
    </property>
    <property name="orientation">
     <enum>Qt::Horizontal</enum>

--- a/Source/GUI/Qt/sheetview.cpp
+++ b/Source/GUI/Qt/sheetview.cpp
@@ -35,7 +35,8 @@ SheetView::SheetView(Core *C, QWidget *parent) :
     refreshDisplay();
     ui->tableWidget->selectRow(0);
 
-    QFont font = ui->label->font();
+    QStringList fonts = { "Cascadia Mono", "Mono" };
+    QFont font(fonts);
     font.setStyleHint(QFont::TypeWriter);
     ui->label->setFont(font);
 }


### PR DESCRIPTION
A collection of improvements made while I was exploring the Qt version of MediaInfo.

- Use MSVC2022 for building the x86_64 Windows build
  - Changes to project file to successfully build using MSVC2022 including fixes for linker errors due to path issues
- Enable Control Flow Guard (CFG) for x86_64 Windows build
  - Enables CFG as [strongly encouraged by Microsoft](https://learn.microsoft.com/en-us/windows/win32/secbp/control-flow-guard).
  - For full protection, MediaInfoLib, ZenLib and zlib should be built with `/guard:cf` enabled in `Project | Properties | Configuration Properties | C/C++ | Code Generation` of their respective Visual Studio Projects.
- Reverts commit https://github.com/MediaArea/MediaInfo/commit/18b6e3ca7d52940c6b0a6a89aebd51672ee0db72
  - This commit it is not cross-platform and causes missing icons in both Windows and Ubuntu.
- Use newer 'Close' icon when available
  - Uses newer `QIcon::fromTheme(QIcon::ThemeIcon::WindowClose)` when built with Qt > 6.7
  - This newer icon is visible in dark mode on Windows unlike previous one.
- Prefer Cascadia Mono font when available
  - For systems with Cascadia Mono font (the default font for Windows Terminal) installed, it will be used else old font selection behaviour is maintained.
  - Cascadia Mono is more readable than the previously selected font on Windows and is also consistent with current VCL version of MediaInfo.
- Prevent toolbar from being moved
  - Previously, it was possible to detach the toolbar.
- Prevent clipped text in easy view
  - Make it resize properly to prevent clipped text in easy view when viewing certain files with multi-line metadata due to text wrap.
- Other improvements
  - Remove unused includes in `mainwindow.cpp`.
  - Fix inconsistent indents in `mainwindow.cpp`.

Tested with Qt 6.7.2 and MSVC2022.

**Windows 11 screenshots:**
![Screenshot 2024-06-19 192245](https://github.com/MediaArea/MediaInfo/assets/77721854/51f31c43-20c0-4040-a31a-4810c879caa9)
_Process Explorer showing 64-bit Qt version with DEP, ASLR, CFG and Per-monitor DPI Awareness enabled_
![Screenshot 2024-06-19 190541](https://github.com/MediaArea/MediaInfo/assets/77721854/f46f4472-41c1-4315-88a2-737b9a5e56cf)
![Screenshot 2024-06-19 190557](https://github.com/MediaArea/MediaInfo/assets/77721854/47a07af8-6a28-4946-993e-438572105a51)
![Screenshot 2024-06-19 190618](https://github.com/MediaArea/MediaInfo/assets/77721854/42148083-7751-47d0-8ed7-561ad1ef4410)

**Ubuntu screenshots:**
![Screenshot from 2024-06-19 19-10-41](https://github.com/MediaArea/MediaInfo/assets/77721854/bfbd2937-e6e8-4e46-9780-2801d5e3039f)
![Screenshot from 2024-06-19 19-10-58](https://github.com/MediaArea/MediaInfo/assets/77721854/bd4ded91-c926-4734-9ab5-0bfbf75baab5)
![Screenshot from 2024-06-19 19-11-10](https://github.com/MediaArea/MediaInfo/assets/77721854/6b59248b-950b-4c69-930c-7c50772bf445)

**Previous screenshots for comparison:**
https://github.com/MediaArea/MediaInfo/pull/857#issuecomment-2152643509
https://github.com/MediaArea/MediaInfo/pull/857#issuecomment-2176644649