### PR TITLE
Windows GUI: Fixes

### DIFF
--- a/Source/GUI/VCL/GUI_Main.cpp
+++ b/Source/GUI/VCL/GUI_Main.cpp
@@ -1077,7 +1077,7 @@ void __fastcall TMainF::Refresh(TTabSheet *Page)
                     else
                     {
                         Buffer[Count]=(int8u)'\0';
-                        Ztring Template=Ztring().From_UTF8((char*)Buffer);
+                        Ztring Template=Ztring().From_UTF8(reinterpret_cast<char*>(Buffer));
                         if (Template.FindAndReplace(__T("@SVG@"), S1)==0)
                             S1=__T("Invalid template");
                         else
@@ -1111,7 +1111,7 @@ void __fastcall TMainF::Refresh(TTabSheet *Page)
             F.Write(S1);
             F.Close();
             //Navigate
-            Page_Custom_HTML->Navigate((MediaInfoNameSpace::Char*)FileName_Temp.c_str());
+            Page_Custom_HTML->Navigate(const_cast<MediaInfoNameSpace::Char*>(FileName_Temp.c_str()));
             FormResize(NULL);
         }
         else
@@ -1146,18 +1146,18 @@ void __fastcall TMainF::Refresh(TTabSheet *Page)
             }
             bool Audio=false;
             bool Subtitle=false;
-            for (size_t I=0; I<List.size(); I++)
+            for (size_t i=0; i<List.size(); ++i)
             {
-                if (List(I, 0)==__T("0000"))
+                if (List(i, 0)==__T("0000"))
                     Audio=true;
-                if (List(I, 0)==__T("S_TEXT/UTF8"))
+                if (List(i, 0)==__T("S_TEXT/UTF8"))
                     Subtitle=true;
                 if (Subtitle)
-                    Page_System_Text.push_back(List.Read(I));
+                    Page_System_Text.push_back(List.Read(i));
                 else if (Audio)
-                    Page_System_Audio.push_back(List.Read(I));
+                    Page_System_Audio.push_back(List.Read(i));
                 else
-                    Page_System_Video.push_back(List.Read(I));
+                    Page_System_Video.push_back(List.Read(i));
             }
 
             //enumerate codecs in system
@@ -1707,7 +1707,7 @@ void __fastcall TMainF::M_Help_SupportedFormatsClick(TObject *Sender)
 void __fastcall TMainF::M_LanguageClick(TObject *Sender)
 {
     //Special case : Languages, should show the name of language in the local version
-    Ztring Title=Prefs->FilesList[Prefs_Language](((TMenuItem*)Sender)->MenuIndex);
+    Ztring Title=Prefs->FilesList[Prefs_Language]((dynamic_cast<TMenuItem*>(Sender))->MenuIndex);
 
     //Load
     Prefs->Load(Prefs_Language, Title);
@@ -2009,7 +2009,7 @@ void __fastcall TMainF::Page_System_SheetColumnClick(TObject *Sender,
       TListColumn *Column)
 {
     Page_System_Sheet_ColumnToSort = Column->Index;
-    ((TCustomListView *)Sender)->AlphaSort();
+    (dynamic_cast<TCustomListView*>(Sender))->AlphaSort();
 }
 
 //---------------------------------------------------------------------------

--- a/Source/GUI/VCL/GUI_Main.cpp
+++ b/Source/GUI/VCL/GUI_Main.cpp
@@ -1171,13 +1171,9 @@ void __fastcall TMainF::Refresh(TTabSheet *Page)
     }
 
     //Form title
-    Ztring Title=GUI_Text(Caption);
-    Title=Title.SubString(__T(""), __T(" - "));
-         if (FilesCount==0)
+    if (FilesCount==0)
         //0 fichier
-    {
         Caption=MEDIAINFO_TITLE;
-    }
     else if (FilesCount==1)
         //un fichier
         Caption=(Ztring(MEDIAINFO_TITLE)+__T(" - ")+I->Get(0, Stream_General, 0, __T("CompleteName"))).c_str();

--- a/Source/GUI/VCL/GUI_Main.cpp
+++ b/Source/GUI/VCL/GUI_Main.cpp
@@ -533,23 +533,24 @@ void __fastcall TMainF::FormResize(TObject *Sender)
         }
 
         //Streams
-        for (int KindOfStream=0; KindOfStream<Stream_Max; ++KindOfStream)
+        for (int KindOfStream = 0; KindOfStream < Stream_Max; ++KindOfStream)
         {
             if (Page_Sheet_X[KindOfStream])
             {
                 if (KindOfStream!=0 && Page_Sheet_X[KindOfStream-1])
-                    Page_Sheet_X[KindOfStream]->Top =Page_Sheet_X[KindOfStream-1]->Top+Page_Sheet_X[KindOfStream-1]->Height;
+                    Page_Sheet_X[KindOfStream]->Top    = Page_Sheet_X[KindOfStream-1]->Top+Page_Sheet_X[KindOfStream-1]->Height;
                 else
-                    Page_Sheet_X[KindOfStream]->Top =0; //1st stream, need reference
-                Page_Sheet_X[KindOfStream]->Width   =Page_Sheet->ClientWidth-Page_Sheet_X_Web[KindOfStream]->Width;
-                Page_Sheet_X_Web[KindOfStream]->Top =Page_Sheet_X[KindOfStream]->Top+1;
-                Page_Sheet_X_Web[KindOfStream]->Left=Page_Sheet_X[KindOfStream]->Width;
+                    Page_Sheet_X[KindOfStream]->Top    = 0; //1st stream, need reference
+                Page_Sheet_X[KindOfStream]->Width      = Page_Sheet->ClientWidth-Page_Sheet_X_Web[KindOfStream]->Width;
+                Page_Sheet_X_Web[KindOfStream]->Top    = Page_Sheet_X[KindOfStream]->Top+1;
+                Page_Sheet_X_Web[KindOfStream]->Left   = Page_Sheet_X[KindOfStream]->Width;
+                Page_Sheet_X_Web[KindOfStream]->Height = Page_Sheet_X[KindOfStream]->Height;
                 if (!Page_Sheet_X[KindOfStream+1]) //reached the bottom
                 {
                     //Bottom
-                    Page_Sheet_Text->Width =Page_Sheet->ClientWidth;
-                    Page_Sheet_Text->Top   =Page_Sheet_X[KindOfStream]->Top+Page_Sheet_X[KindOfStream]->Height;
-                    Page_Sheet_Text->Height=Page_Sheet_Panel2->Height-(Page_Sheet_X[KindOfStream]->Top+Page_Sheet_X[KindOfStream]->Height);
+                    Page_Sheet_Text->Width  = Page_Sheet->ClientWidth;
+                    Page_Sheet_Text->Top    = Page_Sheet_X[KindOfStream]->Top+Page_Sheet_X[KindOfStream]->Height;
+                    Page_Sheet_Text->Height = Page_Sheet_Panel2->Height-(Page_Sheet_X[KindOfStream]->Top+Page_Sheet_X[KindOfStream]->Height);
                 }
             }
         }

--- a/Source/GUI/VCL/GUI_Main.cpp
+++ b/Source/GUI/VCL/GUI_Main.cpp
@@ -542,11 +542,8 @@ void __fastcall TMainF::FormResize(TObject *Sender)
                 else
                     Page_Sheet_X[KindOfStream]->Top =0; //1st stream, need reference
                 Page_Sheet_X[KindOfStream]->Width   =Page_Sheet->ClientWidth-Page_Sheet_X_Web[KindOfStream]->Width;
-                if (Page_Sheet_X_Web[KindOfStream])
-                {
-                    Page_Sheet_X_Web[KindOfStream]->Top =Page_Sheet_X[KindOfStream]->Top+1;
-                    Page_Sheet_X_Web[KindOfStream]->Left=Page_Sheet_X[KindOfStream]->Width;
-                }
+                Page_Sheet_X_Web[KindOfStream]->Top =Page_Sheet_X[KindOfStream]->Top+1;
+                Page_Sheet_X_Web[KindOfStream]->Left=Page_Sheet_X[KindOfStream]->Width;
                 if (!Page_Sheet_X[KindOfStream+1]) //reached the bottom
                 {
                     //Bottom
@@ -762,7 +759,7 @@ void __fastcall TMainF::Refresh(TTabSheet *Page)
     //Easy
          if (Page==Page_Easy)
     {
-        size_t ItemIndex_Save=Page_Easy_File->ItemIndex;
+        int ItemIndex_Save=Page_Easy_File->ItemIndex;
         Page_Easy_File->Items->Clear();
         for (size_t FilePos=0; FilePos<FilesCount; FilePos++)
             Page_Easy_File->Items->Add(I->Get(FilePos, Stream_General, 0, __T("CompleteName")).c_str());
@@ -1272,7 +1269,7 @@ void __fastcall TMainF::M_File_Open_FolderClick(TObject *Sender)
 //---------------------------------------------------------------------------
 void __fastcall TMainF::M_File_Close_FileClick(TObject *Sender)
 {
-    size_t Position=-1;
+    int Position=-1;
     if (Page->ActivePage==Page_Easy)
         Position=Page_Easy_File->ItemIndex;
 

--- a/Source/GUI/VCL/GUI_Main.dfm
+++ b/Source/GUI/VCL/GUI_Main.dfm
@@ -723,7 +723,7 @@ object MainF: TMainF
     EdgeBorders = [ebRight]
     EdgeInner = esNone
     EdgeOuter = esNone
-    Images = Toolbar_Image
+    Images = ToolBar_Image
     ParentColor = False
     ParentShowHint = False
     ShowHint = True
@@ -6009,7 +6009,7 @@ object MainF: TMainF
     Left = 768
     Top = 144
   end
-  object Toolbar_Image: TVirtualImageList
+  object ToolBar_Image: TVirtualImageList
     Images = <
       item
         CollectionIndex = 0

--- a/Source/GUI/VCL/GUI_Main.h
+++ b/Source/GUI/VCL/GUI_Main.h
@@ -215,7 +215,7 @@ __published:    // IDE-managed Components
     TMenuItem *ToolBar_View_Graph_Svg;
     TImageCollection *ImageCollection1;
     TVirtualImageList *Menu_Image;
-    TVirtualImageList *Toolbar_Image;
+    TVirtualImageList *ToolBar_Image;
     TVirtualImageList *ToolBar_Image_Disabled;
     TFileOpenDialog *FileOpenDialog1;
     TFileOpenDialog *FolderOpenDialog1;

--- a/Source/GUI/VCL/GUI_Plugin.dfm
+++ b/Source/GUI/VCL/GUI_Plugin.dfm
@@ -12,10 +12,8 @@ object PluginF: TPluginF
   Font.Height = -11
   Font.Name = 'Arial'
   Font.Style = []
-  OldCreateOrder = False
   Position = poScreenCenter
   OnShow = FormShow
-  PixelsPerInch = 96
   TextHeight = 14
   object InfoLabel: TLabel
     Left = 5
@@ -89,8 +87,8 @@ object PluginF: TPluginF
     Visible = False
   end
   object Cancel: TButton
-    Left = 35
-    Top = 85
+    Left = 62
+    Top = 112
     Width = 122
     Height = 26
     Cancel = True
@@ -99,8 +97,8 @@ object PluginF: TPluginF
     OnClick = CancelClick
   end
   object Install: TButton
-    Left = 160
-    Top = 85
+    Left = 190
+    Top = 112
     Width = 122
     Height = 26
     Caption = 'Install'


### PR DESCRIPTION
- Fix layout of Plugin install window
  - Fix overlapping of buttons with text. Resolves [#913](https://github.com/MediaArea/MediaInfo/issues/913#issuecomment-2227054711).
- Use consistent letter case for ToolBar
  - Change `Toolbar` to `ToolBar` to be consistent.
- Fix issues found by static analysis
  - Fix the following issues found with [Cppcheck](https://github.com/danmar/cppcheck). Use `int` instead of `size_t` as [ItemIndex is of type `int`](https://docwiki.embarcadero.com/Libraries/Athens/en/Vcl.Controls.TCustomListControl.ItemIndex). `size_t` is unsigned and cannot be reliably compared with `-1`.
    ```
    Id: knownConditionTrueFalse
    CWE: 571
    Condition 'ItemIndex_Save!=-1' is always true

    Id: knownConditionTrueFalse
    CWE: 570
    Condition 'Position==-1' is always false
    ```
  - Fix the following issue found with [Cppcheck](https://github.com/danmar/cppcheck) by removing redundant check.
    ```
    Id: nullPointerRedundantCheck
    CWE: 476
    Either the condition 'Page_Sheet_X_Web[KindOfStream]' is redundant or there is possible null pointer dereference: Page_Sheet_X_Web[KindOfStream].
    ```
- Fix issues found by static analysis 2
  - Follow the following recommendations from [Cppcheck](https://github.com/danmar/cppcheck) for 6 occurrences
    ```
    Id: cstyleCast
    CWE: 398
    C-style pointer casting detected. C++ offers four different kinds of casts as replacements: static_cast, const_cast, dynamic_cast and reinterpret_cast. A C-style cast could evaluate to any of those automatically, thus it is considered safer if the programmer explicitly states which kind of cast is expected.
    ```
  - Follow the following recommendation from [Cppcheck](https://github.com/danmar/cppcheck) by renaming `I` to `i` for inside loop usage to prevent confusion since `I` is already used for `MediaInfoList` outside of loop
    ```
    Id: shadowVariable
    CWE: 398
    Local variable 'I' shadows outer variable
    ```
- Fix Sheet view buttons size on high-DPI
  - Fix 'Web' buttons on 'Sheet' view being too large and clipped off on high-DPI displays

- Remove unused string
  - Seems to have reduced the exe size by 0.5KB
