### PR TITLE
Windows GUI: Prevent graph plugin to use negative metrics

### DIFF
--- a/Source/GUI/VCL/GUI_Main.cpp
+++ b/Source/GUI/VCL/GUI_Main.cpp
@@ -255,6 +255,9 @@ __fastcall TMainF::TMainF(TComponent* Owner)
     if (I == NULL)
         I = new MediaInfoList;
 
+    // Intitialize views for HTML output (prevent graphviz plugin from reading invalid metrics)
+    Page_Custom_HTML->Navigate(L"about:blank");
+
     //Load GUI preferences
     GUI_Configure();
 


### PR DESCRIPTION
Snapshot: https://mediaarea.net/download/snapshots/binary/mediainfo-gui/20240827-3/MediaInfo_GUI_24.06.20240827_Windows_x64.exe