### PR TITLE
Text view changes for Windows and Qt GUI

### DIFF
--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -514,15 +514,15 @@ void MainWindow::refreshDisplay() {
             default:
             case VIEW_TEXT:
                 C->Menu_View_Text();
-                viewWidget = new QTextBrowser();
-                ((QTextBrowser*)viewWidget)->setFont(font);
+                viewWidget = new QTextEdit();
+                ((QTextEdit*)viewWidget)->setFont(font);
                 if(ConfigTreeText::getIndex()==0)
-                    ((QTextBrowser*)viewWidget)->setText(wstring2QString(C->Inform_Get()));
+                    ((QTextEdit*)viewWidget)->setText(wstring2QString(C->Inform_Get()));
                 else {
                     for (size_t FilePos=0; FilePos<C->Count_Get(); FilePos++) {
                         for (int streamKind=0;streamKind<4;streamKind++) {
                             if(!ConfigTreeText::getConfigTreeText()->getFields(streamKind).isEmpty())
-                                ((QTextBrowser*)viewWidget)->append("\n"+wstring2QString(C->Get(FilePos, (stream_t)streamKind, 0, __T("StreamKind/String"), Info_Text)));
+                                ((QTextEdit*)viewWidget)->append("\n"+wstring2QString(C->Get(FilePos, (stream_t)streamKind, 0, __T("StreamKind/String"), Info_Text)));
                             for (size_t streamPos=Stream_General; streamPos<C->Count_Get(FilePos, (stream_t)streamKind); streamPos++)
                             {
                                 foreach(QString field, ConfigTreeText::getConfigTreeText()->getFields(streamKind)) {
@@ -530,7 +530,7 @@ void MainWindow::refreshDisplay() {
                                     QString B=wstring2QString(C->Get(FilePos, (stream_t)streamKind, streamPos, QString2wstring(field), Info_Name_Text));
                                     if (B.isEmpty())
                                         B=wstring2QString(C->Get(FilePos, (stream_t)streamKind, streamPos, QString2wstring(field), Info_Name));
-                                    ((QTextBrowser*)viewWidget)->append(B+" : "+A);
+                                    ((QTextEdit*)viewWidget)->append(B+" : "+A);
                                 }
                             }
                         }

--- a/Source/GUI/VCL/GUI_Main.cpp
+++ b/Source/GUI/VCL/GUI_Main.cpp
@@ -356,6 +356,7 @@ void __fastcall TMainF::GUI_Configure()
         Page_Text_Text->Font = MonoFont;
         Page_Custom_Text->Font = MonoFont;
         Page_Sheet_Text->Font = MonoFont;
+        delete MonoFont;
     }
 
     //Menu - View

--- a/Source/GUI/VCL/GUI_Main.dfm
+++ b/Source/GUI/VCL/GUI_Main.dfm
@@ -488,7 +488,7 @@ object MainF: TMainF
           Top = 121
           Width = 604
           Height = 104
-          Color = clWhite
+          Color = 16382457
           EditMargins.Auto = True
           Font.Charset = DEFAULT_CHARSET
           Font.Color = clWindowText
@@ -534,7 +534,7 @@ object MainF: TMainF
         Top = 2
         Width = 628
         Height = 378
-        Color = clWhite
+        Color = 16382457
         Font.Charset = DEFAULT_CHARSET
         Font.Color = clWindowText
         Font.Height = -12
@@ -560,7 +560,7 @@ object MainF: TMainF
         BevelInner = bvNone
         BevelOuter = bvNone
         BorderStyle = bsNone
-        Color = clWhite
+        Color = 16382457
         EditMargins.Auto = True
         Font.Charset = DEFAULT_CHARSET
         Font.Color = clWindowText
@@ -606,7 +606,7 @@ object MainF: TMainF
         BevelInner = bvNone
         BevelOuter = bvNone
         BorderStyle = bsNone
-        Color = clWhite
+        Color = 16382457
         EditMargins.Auto = True
         Font.Charset = DEFAULT_CHARSET
         Font.Color = clWindowText

--- a/Source/GUI/VCL/GUI_Main.dfm
+++ b/Source/GUI/VCL/GUI_Main.dfm
@@ -497,7 +497,6 @@ object MainF: TMainF
           Font.Pitch = fpFixed
           Font.Style = []
           ParentFont = False
-          ReadOnly = True
           ScrollBars = ssVertical
           TabOrder = 8
         end
@@ -571,7 +570,6 @@ object MainF: TMainF
         Font.Style = []
         ParentFont = False
         ParentShowHint = False
-        ReadOnly = True
         ScrollBars = ssBoth
         ShowHint = True
         TabOrder = 0
@@ -617,7 +615,6 @@ object MainF: TMainF
         Font.Pitch = fpFixed
         Font.Style = []
         ParentFont = False
-        ReadOnly = True
         ScrollBars = ssBoth
         TabOrder = 0
       end


### PR DESCRIPTION
- Make VCL GUI Text views editable again due to requests
- Make Qt GUI Text view editable to match VCL GUI behaviour
- Reduce brightness of Text and Tree views in VCL GUI light mode to exactly match the brightness of Easy view and also other Windows apps such as Notepad.

Fix https://github.com/MediaArea/MediaInfo/pull/944#issuecomment-2465416491