### PR TITLE
Windows GUI: Layout improvements

### DIFF
--- a/Source/GUI/VCL/GUI_About.dfm
+++ b/Source/GUI/VCL/GUI_About.dfm
@@ -12,7 +12,7 @@ object AboutF: TAboutF
   Font.Height = -11
   Font.Name = 'Arial'
   Font.Style = []
-  Position = poScreenCenter
+  Position = poOwnerFormCenter
   OnShow = FormShow
   TextHeight = 14
   object Translator: TLabel

--- a/Source/GUI/VCL/GUI_Export.dfm
+++ b/Source/GUI/VCL/GUI_Export.dfm
@@ -11,7 +11,7 @@ object ExportF: TExportF
   Font.Height = -11
   Font.Name = 'Arial'
   Font.Style = []
-  Position = poScreenCenter
+  Position = poOwnerFormCenter
   TextHeight = 14
   object Cancel: TButton
     Left = 373

--- a/Source/GUI/VCL/GUI_Main.cpp
+++ b/Source/GUI/VCL/GUI_Main.cpp
@@ -459,7 +459,7 @@ void __fastcall TMainF::GUI_Configure()
     //Translation
     Translate();
 
-    //Set window size and position
+    //Set window size
     float ScaledScreenWidth=Screen->Width/ScaleFactor;
     float ScaledScreenHeight=Screen->Height/ScaleFactor;
     Width=500;
@@ -474,8 +474,6 @@ void __fastcall TMainF::GUI_Configure()
         Height=600;
     Width*=ScaleFactor;
     Height*=ScaleFactor;
-    Left=(Screen->Width-Width)/2;
-    Top=(Screen->Height-Height)/2;
 }
 
 //---------------------------------------------------------------------------

--- a/Source/GUI/VCL/GUI_Main.dfm
+++ b/Source/GUI/VCL/GUI_Main.dfm
@@ -11,6 +11,7 @@ object MainF: TMainF
   Font.Name = 'Tahoma'
   Font.Style = []
   Menu = MainMenu
+  Position = poScreenCenter
   OnClose = FormClose
   OnDestroy = FormDestroy
   OnResize = FormResize

--- a/Source/GUI/VCL/GUI_Plugin.dfm
+++ b/Source/GUI/VCL/GUI_Plugin.dfm
@@ -12,7 +12,7 @@ object PluginF: TPluginF
   Font.Height = -11
   Font.Name = 'Arial'
   Font.Style = []
-  Position = poScreenCenter
+  Position = poOwnerFormCenter
   OnShow = FormShow
   TextHeight = 14
   object InfoLabel: TLabel

--- a/Source/GUI/VCL/GUI_Preferences.cpp
+++ b/Source/GUI/VCL/GUI_Preferences.cpp
@@ -612,7 +612,7 @@ void __fastcall TPreferencesF::FormShow(TObject *Sender)
     Page->Height=Page->Height+(Page->TabHeight*1.15); //Required with above line
     Cancel->Top=Page->Top+Page->Height+(Cancel->Height*0.15);
     OK->Top=Cancel->Top;
-    ClientHeight=OK->Top+(OK->Height*1.15);
+    ClientHeight=OK->Top+(OK->Height*1.2);
 
     //Make them same size after DPI scaling
     General_Language_More->Height=General_Language_Sel->Height;

--- a/Source/GUI/VCL/GUI_Preferences.dfm
+++ b/Source/GUI/VCL/GUI_Preferences.dfm
@@ -4,20 +4,20 @@ object PreferencesF: TPreferencesF
   BorderIcons = []
   BorderStyle = bsDialog
   Caption = 'Preferences'
-  ClientHeight = 194
-  ClientWidth = 667
+  ClientHeight = 200
+  ClientWidth = 850
   Color = clBtnFace
   Font.Charset = DEFAULT_CHARSET
   Font.Color = clWindowText
   Font.Height = -11
   Font.Name = 'Arial'
   Font.Style = []
-  Position = poDesigned
+  Position = poOwnerFormCenter
   OnShow = FormShow
   TextHeight = 14
   object OK: TButton
-    Left = 540
-    Top = 163
+    Left = 720
+    Top = 166
     Width = 122
     Height = 27
     Caption = 'OK'
@@ -53,8 +53,8 @@ object PreferencesF: TPreferencesF
       084C0061006E0067007500610067006500}
   end
   object Cancel: TButton
-    Left = 415
-    Top = 163
+    Left = 593
+    Top = 166
     Width = 121
     Height = 27
     Cancel = True
@@ -65,8 +65,8 @@ object PreferencesF: TPreferencesF
   object Page: TPageControl
     Left = 176
     Top = 0
-    Width = 490
-    Height = 158
+    Width = 666
+    Height = 160
     ActivePage = Setup
     MultiLine = True
     TabHeight = 22
@@ -75,32 +75,32 @@ object PreferencesF: TPreferencesF
       Caption = 'General'
       OnShow = Setup_GeneralShow
       object Langue_C: TLabel
-        Left = 0
-        Top = 3
+        Left = 2
+        Top = 7
         Width = 54
         Height = 14
         Caption = 'Language :'
       end
       object Output_C: TLabel
-        Left = 0
-        Top = 29
+        Left = 2
+        Top = 33
         Width = 38
         Height = 14
         Caption = 'Output :'
       end
       object General_Language_Sel: TComboBox
-        Left = 124
-        Top = 0
-        Width = 113
+        Left = 164
+        Top = 4
+        Width = 182
         Height = 22
         Style = csDropDownList
         TabOrder = 0
         OnChange = General_Language_SelChange
       end
       object General_Output_Sel: TComboBox
-        Left = 124
-        Top = 26
-        Width = 113
+        Left = 164
+        Top = 30
+        Width = 182
         Height = 22
         Style = csDropDownList
         DropDownCount = 10
@@ -115,9 +115,9 @@ object PreferencesF: TPreferencesF
           'Custom')
       end
       object CB_CheckUpdate: TCheckBox
-        Left = 0
-        Top = 52
-        Width = 506
+        Left = 2
+        Top = 56
+        Width = 655
         Height = 18
         Caption = 'Check for newest versions (require Internet connection)'
         Checked = True
@@ -126,27 +126,27 @@ object PreferencesF: TPreferencesF
         OnClick = CB_CheckUpdateClick
       end
       object General_Language_More: TButton
-        Left = 239
-        Top = 0
-        Width = 57
+        Left = 352
+        Top = 4
+        Width = 105
         Height = 23
         Caption = 'More...'
         TabOrder = 6
         OnClick = General_Language_MoreClick
       end
       object General_Output_More: TButton
-        Left = 239
-        Top = 26
-        Width = 57
+        Left = 352
+        Top = 30
+        Width = 105
         Height = 22
         Caption = 'More...'
         TabOrder = 7
         OnClick = General_Output_MoreClick
       end
       object CB_InfoTip: TCheckBox
-        Left = 0
-        Top = 100
-        Width = 506
+        Left = 2
+        Top = 104
+        Width = 655
         Height = 18
         Caption = 
           'Shell InfoTip (in explorer, move the mouse on file, info will be' +
@@ -155,9 +155,9 @@ object PreferencesF: TPreferencesF
         OnClick = CB_InfoTipClick
       end
       object CB_InscrireShell: TCheckBox
-        Left = 0
-        Top = 68
-        Width = 506
+        Left = 2
+        Top = 72
+        Width = 655
         Height = 18
         Caption = 
           'Shell extension (in explorer, righ click, there will be a "Media' +
@@ -168,9 +168,9 @@ object PreferencesF: TPreferencesF
         OnClick = CB_InscrireShellClick
       end
       object CB_InscrireShell_Folder: TCheckBox
-        Left = 16
-        Top = 84
-        Width = 369
+        Left = 18
+        Top = 88
+        Width = 639
         Height = 17
         Caption = 'For folders too'
         TabOrder = 4
@@ -182,70 +182,70 @@ object PreferencesF: TPreferencesF
       ImageIndex = 1
       OnShow = Setup_AdvancedShow
       object Advanced_DisplayCaptions_Caption: TLabel
-        Left = 0
+        Left = 2
         Top = 105
         Width = 141
         Height = 14
         Caption = 'Handling of 608/708 streams:'
       end
       object CB_ShowToolBar: TCheckBox
-        Left = 0
-        Top = 0
-        Width = 268
+        Left = 2
+        Top = 1
+        Width = 658
         Height = 18
         Caption = 'Show toolbar'
         TabOrder = 0
         OnClick = CB_ShowToolBarClick
       end
       object Advanced_CloseAllAuto: TCheckBox
-        Left = 0
-        Top = 33
-        Width = 268
+        Left = 2
+        Top = 34
+        Width = 658
         Height = 18
         Caption = 'Close all before open'
         TabOrder = 5
         OnClick = Advanced_CloseAllAutoClick
       end
       object CB_ShowMenu: TCheckBox
-        Left = 0
-        Top = 16
-        Width = 268
+        Left = 2
+        Top = 17
+        Width = 658
         Height = 18
         Caption = 'Show menu'
         TabOrder = 2
         OnClick = CB_ShowMenuClick
       end
       object Advanced_InformVersion: TCheckBox
-        Left = 0
-        Top = 50
-        Width = 268
+        Left = 2
+        Top = 51
+        Width = 658
         Height = 18
         Caption = 'Add version to text output'
         TabOrder = 3
         OnClick = Advanced_InformVersionClick
       end
       object Advanced_InformTimestamp: TCheckBox
-        Left = 0
-        Top = 67
-        Width = 268
+        Left = 2
+        Top = 68
+        Width = 658
         Height = 18
         Caption = 'Add creation date to text output'
         TabOrder = 6
         OnClick = Advanced_InformTimestampClick
       end
       object Advanced_EnableFfmpeg: TCheckBox
-        Left = 0
-        Top = 84
-        Width = 268
+        Left = 2
+        Top = 85
+        Width = 658
         Height = 18
         Caption = 'Enable FFmpeg plugin'
         TabOrder = 4
         OnClick = Advanced_EnableFfmpegClick
       end
       object Advanced_DisplayCaptions_Sel: TComboBox
-        Left = 193
+        Left = 303
         Top = 102
-        Width = 285
+        Width = 352
         Height = 22
         Style = csDropDownList
         DropDownCount = 10
@@ -369,18 +369,18 @@ object PreferencesF: TPreferencesF
       ImageIndex = 8
       OnShow = Customize_GraphShow
       object Graph_Adm_ShowTrackUIDs: TCheckBox
-        Left = 0
-        Top = 0
-        Width = 268
+        Left = 2
+        Top = 3
+        Width = 658
         Height = 18
         Caption = 'ADM: Show TrackUIDs'
         TabOrder = 0
         OnClick = Graph_Adm_ShowTrackUIDsClick
       end
       object Graph_Adm_ShowChannelFormats: TCheckBox
-        Left = 0
-        Top = 16
-        Width = 268
+        Left = 2
+        Top = 19
+        Width = 658
         Height = 18
         Caption = 'ADM: Show ChannelFormats'
         TabOrder = 1

--- a/Source/GUI/VCL/GUI_Preferences_Custom.dfm
+++ b/Source/GUI/VCL/GUI_Preferences_Custom.dfm
@@ -13,10 +13,8 @@ object Preferences_CustomF: TPreferences_CustomF
   Font.Height = -11
   Font.Name = 'Arial'
   Font.Style = []
-  OldCreateOrder = False
-  Position = poScreenCenter
+  Position = poOwnerFormCenter
   OnResize = FormResize
-  PixelsPerInch = 96
   TextHeight = 14
   object Liste: TComboBox
     Left = 9

--- a/Source/GUI/VCL/GUI_Preferences_Language.dfm
+++ b/Source/GUI/VCL/GUI_Preferences_Language.dfm
@@ -13,10 +13,8 @@ object Preferences_LanguageF: TPreferences_LanguageF
   Font.Height = -11
   Font.Name = 'Arial'
   Font.Style = []
-  OldCreateOrder = False
-  Position = poScreenCenter
+  Position = poOwnerFormCenter
   OnResize = FormResize
-  PixelsPerInch = 96
   TextHeight = 14
   object Grille: TStringGrid
     Left = 0

--- a/Source/GUI/VCL/GUI_Preferences_Output.dfm
+++ b/Source/GUI/VCL/GUI_Preferences_Output.dfm
@@ -11,9 +11,7 @@ object Preferences_OutputF: TPreferences_OutputF
   Font.Height = -11
   Font.Name = 'Arial'
   Font.Style = []
-  OldCreateOrder = False
-  Position = poScreenCenter
-  PixelsPerInch = 96
+  Position = poOwnerFormCenter
   TextHeight = 14
   object Liste: TComboBox
     Left = 9

--- a/Source/GUI/VCL/GUI_Preferences_Sheet.dfm
+++ b/Source/GUI/VCL/GUI_Preferences_Sheet.dfm
@@ -10,10 +10,8 @@ object Preferences_SheetF: TPreferences_SheetF
   Font.Height = -11
   Font.Name = 'Arial'
   Font.Style = []
-  OldCreateOrder = False
-  Position = poScreenCenter
+  Position = poOwnerFormCenter
   OnResize = FormResize
-  PixelsPerInch = 96
   TextHeight = 14
   object Column_Text0: TLabel
     Left = 362
@@ -36,7 +34,6 @@ object Preferences_SheetF: TPreferences_SheetF
     Width = 156
     Height = 22
     Style = csDropDownList
-    ItemHeight = 0
     TabOrder = 0
     Visible = False
     OnChange = Column_Parameter0Change
@@ -47,7 +44,6 @@ object Preferences_SheetF: TPreferences_SheetF
     Width = 87
     Height = 22
     Style = csDropDownList
-    ItemHeight = 0
     TabOrder = 1
     Visible = False
     OnChange = Column_Kind0Change
@@ -58,7 +54,6 @@ object Preferences_SheetF: TPreferences_SheetF
     Width = 44
     Height = 22
     Style = csDropDownList
-    ItemHeight = 0
     TabOrder = 2
     OnChange = ColumnsCountChange
   end
@@ -99,7 +94,6 @@ object Preferences_SheetF: TPreferences_SheetF
     Top = 95
     Width = 52
     Height = 22
-    ItemHeight = 0
     TabOrder = 6
     Visible = False
   end
@@ -109,7 +103,6 @@ object Preferences_SheetF: TPreferences_SheetF
     Width = 53
     Height = 22
     Style = csDropDownList
-    ItemHeight = 0
     TabOrder = 7
     Visible = False
     OnChange = Column_Pos0Change

--- a/Source/GUI/VCL/GUI_Web.dfm
+++ b/Source/GUI/VCL/GUI_Web.dfm
@@ -12,7 +12,7 @@ object WebF: TWebF
   Font.Height = -11
   Font.Name = 'MS Sans Serif'
   Font.Style = []
-  Position = poDesktopCenter
+  Position = poOwnerFormCenter
   WindowState = wsMinimized
   TextHeight = 13
   object Browser: TWebBrowser


### PR DESCRIPTION
Partial solution for #948
- Resize Preferences window and improve layout to ensure no tabs appear and that all languages that have long text strings are displayed fully without overflow/clipping.
- Make all modal windows spawn at the center of their parent window.
- Use VCL setting to make main form window centered instead of doing manually using code.