### PR TITLE
Windows GUI: Reset Text and Tree views colours to default

### DIFF
--- a/Source/GUI/VCL/GUI_Main.dfm
+++ b/Source/GUI/VCL/GUI_Main.dfm
@@ -489,7 +489,6 @@ object MainF: TMainF
           Top = 121
           Width = 604
           Height = 104
-          Color = 16382457
           EditMargins.Auto = True
           Font.Charset = DEFAULT_CHARSET
           Font.Color = clWindowText
@@ -535,7 +534,6 @@ object MainF: TMainF
         Top = 2
         Width = 628
         Height = 378
-        Color = 16382457
         Font.Charset = DEFAULT_CHARSET
         Font.Color = clWindowText
         Font.Height = -12
@@ -561,7 +559,6 @@ object MainF: TMainF
         BevelInner = bvNone
         BevelOuter = bvNone
         BorderStyle = bsNone
-        Color = 16382457
         EditMargins.Auto = True
         Font.Charset = DEFAULT_CHARSET
         Font.Color = clWindowText
@@ -607,7 +604,6 @@ object MainF: TMainF
         BevelInner = bvNone
         BevelOuter = bvNone
         BorderStyle = bsNone
-        Color = 16382457
         EditMargins.Auto = True
         Font.Charset = DEFAULT_CHARSET
         Font.Color = clWindowText


### PR DESCRIPTION
The final change for Tree and Text view background colour. Use the default colour selected by VCL / Windows for these kind of views. Any dissatisfaction is no longer the responsibility of MediaInfo's codes.