### PR TITLE
Qt GUI: Use WebEngine for HTML view

### DIFF
--- a/Project/QMake/GUI/MediaInfoQt.pro
+++ b/Project/QMake/GUI/MediaInfoQt.pro
@@ -2,7 +2,7 @@
 # Project created by QtCreator 2010-07-23T13:03:11
 # -------------------------------------------------
 
-QT += core gui widgets network xml
+QT += core gui widgets network xml webenginewidgets
 
 win32|macx {
     TARGET = "MediaInfo"

--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -32,6 +32,7 @@
 #include <QToolBar>
 #include <QMainWindow>
 #include <QMenuBar>
+#include <QWebEngineView>
 /*
 #include <qwt/qwt_plot.h>
 #include <qwt/qwt_plot_curve.h>
@@ -659,8 +660,8 @@ void MainWindow::refreshDisplay() {
                 break;
             case VIEW_HTML:
                 C->Menu_View_HTML();
-                viewWidget = new QTextBrowser();
-                ((QTextBrowser*)viewWidget)->setHtml(wstring2QString(C->Inform_Get()));
+                viewWidget = new QWebEngineView();
+                ((QWebEngineView*)viewWidget)->setHtml(wstring2QString(C->Inform_Get()));
                 break;
             case VIEW_TREE:
                 C->Menu_View_Tree();


### PR DESCRIPTION
Use WebEngine for HTML view to render the HTML properly.