### PR TITLE
Qt GUI: Fixes and improvements

### DIFF
--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -515,6 +515,8 @@ void MainWindow::refreshDisplay() {
             default:
             case VIEW_TEXT:
                 C->Menu_View_Text();
+                C->Menu_Option_Preferences_Option(__T("Inform_Version"), settings->value("informVersion",false).toBool() ? __T("1") : __T("0"));
+                C->Menu_Option_Preferences_Option(__T("Inform_Timestamp"), settings->value("informTimestamp",false).toBool() ? __T("1") : __T("0"));
                 viewWidget = new QTextEdit();
                 ((QTextEdit*)viewWidget)->setFont(font);
                 if(ConfigTreeText::getIndex()==0)

--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -500,6 +500,18 @@ void MainWindow::refreshDisplay() {
     ui->actionClose_All->setEnabled(C->Count_Get()>0);
     QDomDocument* xis;
 
+    switch(settings->value("displayCaptions",1).toInt()) {
+    case 0:
+        C->Menu_Option_Preferences_Option(__T("File_DisplayCaptions"),__T("Content"));
+        break;
+    case 1:
+        C->Menu_Option_Preferences_Option(__T("File_DisplayCaptions"),__T("Command"));
+        break;
+    case 2:
+        C->Menu_Option_Preferences_Option(__T("File_DisplayCaptions"),__T("Stream"));
+        break;
+    }
+
     if(C->Count_Get()<=0) {
 #if defined(_WIN32) && defined(WINAPI_FAMILY) && WINAPI_FAMILY==WINAPI_FAMILY_APP //UWP Application
         viewWidget = new QLabel(Tr("You must at least open 1 file.\nOpen a file or a directory."));

--- a/Source/GUI/Qt/mainwindow.ui
+++ b/Source/GUI/Qt/mainwindow.ui
@@ -100,17 +100,14 @@
    <property name="windowTitle">
     <string>toolBar</string>
    </property>
-   <property name="movable">
-    <bool>false</bool>
-   </property>
-   <property name="orientation">
-    <enum>Qt::Horizontal</enum>
-   </property>
    <property name="iconSize">
     <size>
      <width>32</width>
      <height>32</height>
     </size>
+   </property>
+   <property name="floatable">
+    <bool>false</bool>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>

--- a/Source/GUI/Qt/prefs.cpp
+++ b/Source/GUI/Qt/prefs.cpp
@@ -46,6 +46,7 @@ Preferences::Preferences(QSettings* settings, Core* C, QWidget *parent) :
     ui->showToolbar->setChecked(settings->value("showToolbar",true).toBool());
     ui->closeAllBeforeOpen->setChecked(settings->value("closeBeforeOpen",true).toBool());
     ui->comboBox_defaultview->setCurrentIndex(settings->value("defaultView",VIEW_EASY).toInt());
+    ui->shellExtension->setChecked(settings->value("shellExtension",true).toBool());
 #ifdef NEW_VERSION
     ui->checkForNewVersion->setChecked(settings->value("checkForNewVersion",true).toBool());
 #else
@@ -106,6 +107,7 @@ void Preferences::saveSettings() {
     settings->setValue("defaultView",ui->comboBox_defaultview->currentIndex());
     settings->setValue("rememberToolBarPosition",ui->rememberToolBarPosition->isChecked());
     settings->setValue("rememberGeometry",ui->rememberGeometry->isChecked());
+    settings->setValue("shellExtension",ui->shellExtension->isChecked());
     Sheet::setDefault(ui->comboBoxSheet->itemData(ui->comboBoxSheet->currentIndex()).toInt());
     Sheet::save(settings);
     ConfigTreeText::setDefault(ui->treeTextComboBox->itemData(ui->treeTextComboBox->currentIndex()).toInt());

--- a/Source/GUI/Qt/prefs.cpp
+++ b/Source/GUI/Qt/prefs.cpp
@@ -49,6 +49,7 @@ Preferences::Preferences(QSettings* settings, Core* C, QWidget *parent) :
     ui->shellExtension->setChecked(settings->value("shellExtension",true).toBool());
     ui->informVersion->setChecked(settings->value("informVersion",false).toBool());
     ui->informTimestamp->setChecked(settings->value("informTimestamp",false).toBool());
+    ui->displayCaptions->setCurrentIndex(settings->value("displayCaptions",1).toInt());
 #ifdef NEW_VERSION
     ui->checkForNewVersion->setChecked(settings->value("checkForNewVersion",true).toBool());
 #else
@@ -112,6 +113,7 @@ void Preferences::saveSettings() {
     settings->setValue("shellExtension",ui->shellExtension->isChecked());
     settings->setValue("informVersion",ui->informVersion->isChecked());
     settings->setValue("informTimestamp",ui->informTimestamp->isChecked());
+    settings->setValue("displayCaptions",ui->displayCaptions->currentIndex());
     Sheet::setDefault(ui->comboBoxSheet->itemData(ui->comboBoxSheet->currentIndex()).toInt());
     Sheet::save(settings);
     ConfigTreeText::setDefault(ui->treeTextComboBox->itemData(ui->treeTextComboBox->currentIndex()).toInt());

--- a/Source/GUI/Qt/prefs.cpp
+++ b/Source/GUI/Qt/prefs.cpp
@@ -47,6 +47,8 @@ Preferences::Preferences(QSettings* settings, Core* C, QWidget *parent) :
     ui->closeAllBeforeOpen->setChecked(settings->value("closeBeforeOpen",true).toBool());
     ui->comboBox_defaultview->setCurrentIndex(settings->value("defaultView",VIEW_EASY).toInt());
     ui->shellExtension->setChecked(settings->value("shellExtension",true).toBool());
+    ui->informVersion->setChecked(settings->value("informVersion",false).toBool());
+    ui->informTimestamp->setChecked(settings->value("informTimestamp",false).toBool());
 #ifdef NEW_VERSION
     ui->checkForNewVersion->setChecked(settings->value("checkForNewVersion",true).toBool());
 #else
@@ -108,6 +110,8 @@ void Preferences::saveSettings() {
     settings->setValue("rememberToolBarPosition",ui->rememberToolBarPosition->isChecked());
     settings->setValue("rememberGeometry",ui->rememberGeometry->isChecked());
     settings->setValue("shellExtension",ui->shellExtension->isChecked());
+    settings->setValue("informVersion",ui->informVersion->isChecked());
+    settings->setValue("informTimestamp",ui->informTimestamp->isChecked());
     Sheet::setDefault(ui->comboBoxSheet->itemData(ui->comboBoxSheet->currentIndex()).toInt());
     Sheet::save(settings);
     ConfigTreeText::setDefault(ui->treeTextComboBox->itemData(ui->treeTextComboBox->currentIndex()).toInt());

--- a/Source/GUI/Qt/prefs.ui
+++ b/Source/GUI/Qt/prefs.ui
@@ -241,6 +241,32 @@
           <string>Remember Window Geometry</string>
          </property>
         </widget>
+        <widget class="QCheckBox" name="informVersion">
+         <property name="geometry">
+          <rect>
+           <x>10</x>
+           <y>160</y>
+           <width>271</width>
+           <height>22</height>
+          </rect>
+         </property>
+         <property name="text">
+          <string>Add version to text output</string>
+         </property>
+        </widget>
+        <widget class="QCheckBox" name="informTimestamp">
+         <property name="geometry">
+          <rect>
+           <x>10</x>
+           <y>190</y>
+           <width>271</width>
+           <height>22</height>
+          </rect>
+         </property>
+         <property name="text">
+          <string>Add creation date to text output</string>
+         </property>
+        </widget>
        </widget>
        <widget class="QWidget" name="Sheet">
         <property name="sizePolicy">

--- a/Source/GUI/Qt/prefs.ui
+++ b/Source/GUI/Qt/prefs.ui
@@ -23,16 +23,6 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
-   <item row="1" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
    <item row="0" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
@@ -109,7 +99,7 @@
      <item>
       <widget class="QStackedWidget" name="stackedWidget">
        <property name="currentIndex">
-        <number>4</number>
+        <number>0</number>
        </property>
        <widget class="QWidget" name="Setup">
         <property name="sizePolicy">
@@ -120,25 +110,8 @@
         </property>
         <layout class="QGridLayout" name="gridLayout" columnstretch="25,0">
          <property name="sizeConstraint">
-          <enum>QLayout::SetFixedSize</enum>
+          <enum>QLayout::SizeConstraint::SetFixedSize</enum>
          </property>
-         <item row="1" column="0">
-          <widget class="QCheckBox" name="checkForNewVersion">
-           <property name="text">
-            <string>Check for new versions</string>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="1">
-          <widget class="QComboBox" name="comboBox_defaultview">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-          </widget>
-         </item>
          <item row="0" column="0">
           <widget class="QLabel" name="label_2">
            <property name="text">
@@ -153,17 +126,10 @@
            </property>
           </widget>
          </item>
-         <item row="2" column="0">
-          <widget class="QCheckBox" name="shellExtension">
-           <property name="text">
-            <string>Shell extension</string>
-           </property>
-          </widget>
-         </item>
          <item row="4" column="0">
           <spacer name="verticalSpacer_5">
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -173,100 +139,145 @@
            </property>
           </spacer>
          </item>
+         <item row="1" column="0">
+          <widget class="QCheckBox" name="checkForNewVersion">
+           <property name="text">
+            <string>Check for new versions</string>
+           </property>
+          </widget>
+         </item>
+         <item row="2" column="0">
+          <widget class="QCheckBox" name="shellExtension">
+           <property name="text">
+            <string>Shell extension</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QComboBox" name="comboBox_defaultview">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+          </widget>
+         </item>
         </layout>
        </widget>
        <widget class="QWidget" name="Advanced">
-        <widget class="QCheckBox" name="showToolbar">
-         <property name="geometry">
-          <rect>
-           <x>9</x>
-           <y>40</y>
-           <width>271</width>
-           <height>22</height>
-          </rect>
-         </property>
-         <property name="text">
-          <string>Show toolbar</string>
-         </property>
-        </widget>
-        <widget class="QCheckBox" name="showMenu">
-         <property name="geometry">
-          <rect>
-           <x>9</x>
-           <y>100</y>
-           <width>271</width>
-           <height>22</height>
-          </rect>
-         </property>
-         <property name="text">
-          <string>Show menu</string>
-         </property>
-        </widget>
-        <widget class="QCheckBox" name="closeAllBeforeOpen">
-         <property name="geometry">
-          <rect>
-           <x>9</x>
-           <y>10</y>
-           <width>271</width>
-           <height>22</height>
-          </rect>
-         </property>
-         <property name="text">
-          <string>Close all before open</string>
-         </property>
-        </widget>
-        <widget class="QCheckBox" name="rememberToolBarPosition">
-         <property name="geometry">
-          <rect>
-           <x>50</x>
-           <y>70</y>
-           <width>231</width>
-           <height>22</height>
-          </rect>
-         </property>
-         <property name="text">
-          <string>Remember its position</string>
-         </property>
-        </widget>
-        <widget class="QCheckBox" name="rememberGeometry">
-         <property name="geometry">
-          <rect>
-           <x>9</x>
-           <y>130</y>
-           <width>271</width>
-           <height>22</height>
-          </rect>
-         </property>
-         <property name="text">
-          <string>Remember Window Geometry</string>
-         </property>
-        </widget>
-        <widget class="QCheckBox" name="informVersion">
-         <property name="geometry">
-          <rect>
-           <x>10</x>
-           <y>160</y>
-           <width>271</width>
-           <height>22</height>
-          </rect>
-         </property>
-         <property name="text">
-          <string>Add version to text output</string>
-         </property>
-        </widget>
-        <widget class="QCheckBox" name="informTimestamp">
-         <property name="geometry">
-          <rect>
-           <x>10</x>
-           <y>190</y>
-           <width>271</width>
-           <height>22</height>
-          </rect>
-         </property>
-         <property name="text">
-          <string>Add creation date to text output</string>
-         </property>
-        </widget>
+        <layout class="QGridLayout" name="gridLayout_2">
+         <item row="16" column="1">
+          <widget class="QComboBox" name="displayCaptions">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="currentIndex">
+            <number>1</number>
+           </property>
+           <item>
+            <property name="text">
+             <string>When content is detected</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>When content or a command is detected</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Even when no content or command is detected</string>
+            </property>
+           </item>
+          </widget>
+         </item>
+         <item row="12" column="0" colspan="2">
+          <widget class="QCheckBox" name="rememberGeometry">
+           <property name="text">
+            <string>Remember Window Geometry</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="0" colspan="2">
+          <widget class="QCheckBox" name="closeAllBeforeOpen">
+           <property name="text">
+            <string>Close all before open</string>
+           </property>
+          </widget>
+         </item>
+         <item row="16" column="0">
+          <widget class="QLabel" name="displayCaptions_label">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Handling of 608/708 streams:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="0" colspan="2">
+          <widget class="QCheckBox" name="showMenu">
+           <property name="text">
+            <string>Show menu</string>
+           </property>
+          </widget>
+         </item>
+         <item row="14" column="0" colspan="2">
+          <widget class="QCheckBox" name="informTimestamp">
+           <property name="text">
+            <string>Add creation date to text output</string>
+           </property>
+          </widget>
+         </item>
+         <item row="13" column="0" colspan="2">
+          <widget class="QCheckBox" name="informVersion">
+           <property name="text">
+            <string>Add version to text output</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0" colspan="2">
+          <widget class="QCheckBox" name="showToolbar">
+           <property name="text">
+            <string>Show toolbar</string>
+           </property>
+          </widget>
+         </item>
+         <item row="17" column="0" colspan="2">
+          <spacer name="verticalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Orientation::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="6" column="0" rowspan="2" colspan="2">
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <property name="leftMargin">
+            <number>25</number>
+           </property>
+           <item>
+            <widget class="QCheckBox" name="rememberToolBarPosition">
+             <property name="text">
+              <string>Remember its position</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
        </widget>
        <widget class="QWidget" name="Sheet">
         <property name="sizePolicy">
@@ -295,7 +306,7 @@
          <item>
           <spacer name="verticalSpacer">
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -353,7 +364,7 @@
          <item>
           <spacer name="verticalSpacer_2">
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -411,7 +422,7 @@
          <item>
           <spacer name="verticalSpacer_3">
            <property name="orientation">
-            <enum>Qt::Vertical</enum>
+            <enum>Qt::Orientation::Vertical</enum>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
@@ -451,6 +462,16 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item row="1" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
Qt GUI: Make toolbar moveable but prevent it from being detached
- Correction of 43289a54085aa55d5a881d94f1278a942138501e
- Turns out the toolbar was designed to be moveable. The main intention of the previous commit was to prevent toolbar from being detached from main window. Now it is moveable but must be docked to one of the four sides of the window.

Qt GUI: Save shell extension preference
- Prepare for future integration with IExplorerCommand-based shell extension on Windows.
- The saved preference can be read from registry by the IExplorerCommand implementation to decide if it should be visible.

Qt GUI: Add inform version and timestamp options
- Something that the VCL GUI has

Qt GUI: Add captions display options
- Match other toolkit versions
