### PR TITLE
Qt GUI: Fixes and improvements 2

### DIFF
--- a/Project/QMake/GUI/MediaInfoQt.pro
+++ b/Project/QMake/GUI/MediaInfoQt.pro
@@ -200,6 +200,7 @@ unix:LIBS += -ldl \
               -lz
 
 SOURCES += ../../../Source/GUI/Qt/main.cpp \
+    ../../../Source/GUI/Qt/graphplugin.cpp \
     ../../../Source/GUI/Qt/mainwindow.cpp \
     ../../../Source/Common/Core.cpp \
     ../../../Source/GUI/Qt/custom.cpp \
@@ -220,6 +221,7 @@ SOURCES += ../../../Source/GUI/Qt/main.cpp \
 HEADERS += ../../../Source/GUI/Qt/mainwindow.h \
     ../../../Source/Common/Core.h \
     ../../../Source/GUI/Qt/easyviewwidget.h \
+    ../../../Source/GUI/Qt/graphplugin.h \
     ../../../Source/GUI/Qt/prefs.h \
     ../../../Source/GUI/Qt/views.h \
     ../../../Source/GUI/Qt/custom.h \

--- a/Source/GUI/Qt/export.cpp
+++ b/Source/GUI/Qt/export.cpp
@@ -85,6 +85,8 @@ QString Export::extension(int mode) {
         break;
     case HTML: return "html";
         break;
+    case GRAPH: return "svg";
+        break;
     case XML:
     case PBCORE:
     case PBCORE2:
@@ -113,6 +115,8 @@ QString Export::extensionName(int mode) {
     case TEXT: return tr("Text");
         break;
     case HTML: return "HTML";
+        break;
+    case GRAPH: return tr("Graph");
         break;
     case XML:
     case PBCORE:
@@ -146,6 +150,8 @@ QString Export::name(int mode) {
     case XML: return Tr("XML");
         break;
     case JSON: return Tr("JSON");
+        break;
+    case GRAPH: return Tr("Graph");
         break;
     case PBCORE: return Tr("PBCore");
         break;
@@ -194,6 +200,7 @@ void Export::on_comboBoxMode_currentIndexChanged(int index)
         break;
     case XML:
     case JSON:
+    case GRAPH:
     case PBCORE:
     case PBCORE2:
     case MPEG7_Strict:

--- a/Source/GUI/Qt/export.h
+++ b/Source/GUI/Qt/export.h
@@ -23,6 +23,7 @@ public:
         HTML=1,
         XML,
         JSON,
+        GRAPH,
         PBCORE,
         PBCORE2,
         EBUCORE_1_5,

--- a/Source/GUI/Qt/graphplugin.cpp
+++ b/Source/GUI/Qt/graphplugin.cpp
@@ -1,0 +1,60 @@
+/*  Copyright (c) MediaArea.net SARL. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
+
+#include "graphplugin.h"
+#include "ZenLib/Ztring.h"
+#include "ZenLib/File.h"
+#include <QApplication>
+
+#define wstring2QString(_DATA) \
+    QString::fromUtf8(Ztring(_DATA).To_UTF8().c_str())
+#define QString2wstring(_DATA) \
+    Ztring().From_UTF8(_DATA.toUtf8())
+
+using namespace ZenLib;
+
+QString Generate_Graph_HTML(Core *C) {
+
+    C->Menu_Option_Preferences_Inform(__T("Graph_Svg"));
+
+    Ztring S1 = Ztring();
+    Ztring InstallFolder =
+        QString2wstring(QCoreApplication::applicationDirPath());
+    Ztring State = C->Menu_Option_Preferences_Option(
+        __T("Info_Graph_Svg_Plugin_State"), __T(""));
+    if (State == __T("1")) {
+        for (size_t Pos = 0; Pos < C->Count_Get(); Pos++) {
+            Ztring Svg = C->MI->Inform(Pos);
+            size_t Pos2 = Svg.find(__T("<svg"));
+            if (Pos2 != std::string::npos)
+                Svg = Svg.substr(Pos);
+            S1 += (Pos2 ? __T("<br/>") : __T("")) + Svg;
+        }
+
+        if (File::Exists(InstallFolder + __T("\\Plugin\\Graph\\Template.html"))) {
+            File F(InstallFolder + __T("\\Plugin\\Graph\\Template.html"));
+            int8u *Buffer = new int8u[(size_t)F.Size_Get() + 1];
+            size_t Count = F.Read(Buffer, (size_t)F.Size_Get());
+            if (Count == ZenLib::Error) {
+                S1 = __T("Unable to load graph template");
+            } else {
+                Buffer[Count] = (int8u)'\0';
+                Ztring Template = Ztring().From_UTF8(reinterpret_cast<char *>(Buffer));
+                if (Template.FindAndReplace(__T("@SVG@"), S1) == 0)
+                    S1 = __T("Invalid template");
+                else
+                    S1 = Template;
+            }
+            delete[] Buffer;
+        } else
+            S1 = __T("Graph template not found");
+    } else if (State == __T("0"))
+        S1 = __T("Graph plugin not installed");
+    else
+        S1 = State;
+
+    return wstring2QString(S1);
+}

--- a/Source/GUI/Qt/graphplugin.h
+++ b/Source/GUI/Qt/graphplugin.h
@@ -1,0 +1,15 @@
+/*  Copyright (c) MediaArea.net SARL. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
+
+#ifndef GRAPHPLUGIN_H
+#define GRAPHPLUGIN_H
+
+#include <QString>
+#include "Common/Core.h"
+
+QString Generate_Graph_HTML(Core* C);
+
+#endif // GRAPHPLUGIN_H

--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -500,6 +500,8 @@ void MainWindow::refreshDisplay() {
     ui->actionClose_All->setEnabled(C->Count_Get()>0);
     QDomDocument* xis;
 
+    C->Menu_Option_Preferences_Option(__T("Enable_Ffmpeg"), settings->value("enableFFmpeg",false).toBool() ? __T("1") : __T("0"));
+
     switch(settings->value("displayCaptions",1).toInt()) {
     case 0:
         C->Menu_Option_Preferences_Option(__T("File_DisplayCaptions"),__T("Content"));

--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -529,15 +529,15 @@ void MainWindow::refreshDisplay() {
                 C->Menu_View_Text();
                 C->Menu_Option_Preferences_Option(__T("Inform_Version"), settings->value("informVersion",false).toBool() ? __T("1") : __T("0"));
                 C->Menu_Option_Preferences_Option(__T("Inform_Timestamp"), settings->value("informTimestamp",false).toBool() ? __T("1") : __T("0"));
-                viewWidget = new QTextEdit();
-                ((QTextEdit*)viewWidget)->setFont(font);
+                viewWidget = new QTextBrowser();
+                ((QTextBrowser*)viewWidget)->setFont(font);
                 if(ConfigTreeText::getIndex()==0)
-                    ((QTextEdit*)viewWidget)->setText(wstring2QString(C->Inform_Get()));
+                    ((QTextBrowser*)viewWidget)->setText(wstring2QString(C->Inform_Get()));
                 else {
                     for (size_t FilePos=0; FilePos<C->Count_Get(); FilePos++) {
                         for (int streamKind=0;streamKind<4;streamKind++) {
                             if(!ConfigTreeText::getConfigTreeText()->getFields(streamKind).isEmpty())
-                                ((QTextEdit*)viewWidget)->append("\n"+wstring2QString(C->Get(FilePos, (stream_t)streamKind, 0, __T("StreamKind/String"), Info_Text)));
+                                ((QTextBrowser*)viewWidget)->append("\n"+wstring2QString(C->Get(FilePos, (stream_t)streamKind, 0, __T("StreamKind/String"), Info_Text)));
                             for (size_t streamPos=Stream_General; streamPos<C->Count_Get(FilePos, (stream_t)streamKind); streamPos++)
                             {
                                 foreach(QString field, ConfigTreeText::getConfigTreeText()->getFields(streamKind)) {
@@ -545,7 +545,7 @@ void MainWindow::refreshDisplay() {
                                     QString B=wstring2QString(C->Get(FilePos, (stream_t)streamKind, streamPos, QString2wstring(field), Info_Name_Text));
                                     if (B.isEmpty())
                                         B=wstring2QString(C->Get(FilePos, (stream_t)streamKind, streamPos, QString2wstring(field), Info_Name));
-                                    ((QTextEdit*)viewWidget)->append(B+" : "+A);
+                                    ((QTextBrowser*)viewWidget)->append(B+" : "+A);
                                 }
                             }
                         }

--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -431,7 +431,7 @@ void MainWindow::openFiles(QStringList fileNames) {
     for(int i=0;i<fileNames.size();i++) {
         fileNames[i] = QDir::toNativeSeparators(fileNames[i]);
     }
-    C->Menu_File_Open_Files_Begin(settings->value("closeBeforeOpen",true).toBool(), false);
+    C->Menu_File_Open_Files_Begin(settings->value("closeBeforeOpen",true).toBool(), true);
     for (int Pos=0; Pos<fileNames.size(); Pos++)
         C->Menu_File_Open_Files_Continue(QString2wstring(fileNames[Pos]));
     openTimerInit();
@@ -481,7 +481,7 @@ void MainWindow::openDir(QString dirName) {
 
     //Configuring
     dirName = QDir::toNativeSeparators(dirName);
-    C->Menu_File_Open_Files_Begin(settings->value("closeBeforeOpen",true).toBool(), false);
+    C->Menu_File_Open_Files_Begin(settings->value("closeBeforeOpen",true).toBool(), true);
     C->Menu_File_Open_Directory(QString2wstring(dirName));
     openTimerInit();
 

--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -16,6 +16,7 @@
 #include "sheet.h"
 #include "configtreetext.h"
 #include "custom.h"
+#include "graphplugin.h"
 
 #include <QDropEvent>
 #include <QFileDialog>
@@ -678,6 +679,10 @@ void MainWindow::refreshDisplay() {
                 C->Menu_View_HTML();
                 viewWidget = new QWebEngineView();
                 ((QWebEngineView*)viewWidget)->setHtml(wstring2QString(C->Inform_Get()));
+                break;
+            case VIEW_GRAPH:
+                viewWidget = new QWebEngineView();
+                ((QWebEngineView*)viewWidget)->setHtml(Generate_Graph_HTML(C));
                 break;
             case VIEW_TREE:
                 C->Menu_View_Tree();

--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -1131,6 +1131,10 @@ void MainWindow::on_actionExport_triggered()
             C->Menu_View_HTML();
             file.write(wstring2QString(C->Inform_Get()).toStdString().c_str());
             break;
+        case Export::GRAPH:
+            C->Menu_Option_Preferences_Inform(__T("Graph_Svg"));
+            file.write(wstring2QString(C->Inform_Get()).toStdString().c_str());
+            break;
         case Export::XML:
             C->Menu_View_XML();
             file.write(wstring2QString(C->Inform_Get()).toStdString().c_str());

--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -907,6 +907,7 @@ void MainWindow::applySettings() {
     ui->toolBar->setVisible(settings->value("showToolbar",true).toBool());
     ui->toolBar->setToolButtonStyle(Qt::ToolButtonStyle(settings->value("iconStyle",Qt::ToolButtonIconOnly).toInt()));
     ui->toolBar->setIconSize(settings->value("iconSize",QSize(32,32)).toSize());
+    C->Menu_Option_Preferences_Option(__T("LegacyStreamDisplay"), settings->value("legacyStreamDisplay",false).toBool() ? __T("1") : __T("0"));
 }
 
 void MainWindow::dropEvent(QDropEvent *event)

--- a/Source/GUI/Qt/prefs.cpp
+++ b/Source/GUI/Qt/prefs.cpp
@@ -50,6 +50,7 @@ Preferences::Preferences(QSettings* settings, Core* C, QWidget *parent) :
     ui->informVersion->setChecked(settings->value("informVersion",false).toBool());
     ui->informTimestamp->setChecked(settings->value("informTimestamp",false).toBool());
     ui->displayCaptions->setCurrentIndex(settings->value("displayCaptions",1).toInt());
+    ui->legacyStreamDisplay->setChecked(settings->value("legacyStreamDisplay",false).toBool());
 #ifdef NEW_VERSION
     ui->checkForNewVersion->setChecked(settings->value("checkForNewVersion",true).toBool());
 #else
@@ -114,6 +115,7 @@ void Preferences::saveSettings() {
     settings->setValue("informVersion",ui->informVersion->isChecked());
     settings->setValue("informTimestamp",ui->informTimestamp->isChecked());
     settings->setValue("displayCaptions",ui->displayCaptions->currentIndex());
+    settings->setValue("legacyStreamDisplay",ui->legacyStreamDisplay->isChecked());
     Sheet::setDefault(ui->comboBoxSheet->itemData(ui->comboBoxSheet->currentIndex()).toInt());
     Sheet::save(settings);
     ConfigTreeText::setDefault(ui->treeTextComboBox->itemData(ui->treeTextComboBox->currentIndex()).toInt());

--- a/Source/GUI/Qt/prefs.cpp
+++ b/Source/GUI/Qt/prefs.cpp
@@ -51,6 +51,7 @@ Preferences::Preferences(QSettings* settings, Core* C, QWidget *parent) :
     ui->informTimestamp->setChecked(settings->value("informTimestamp",false).toBool());
     ui->displayCaptions->setCurrentIndex(settings->value("displayCaptions",1).toInt());
     ui->legacyStreamDisplay->setChecked(settings->value("legacyStreamDisplay",false).toBool());
+    ui->enableFFmpeg->setChecked(settings->value("enableFFmpeg",false).toBool());
 #ifdef NEW_VERSION
     ui->checkForNewVersion->setChecked(settings->value("checkForNewVersion",true).toBool());
 #else
@@ -116,6 +117,7 @@ void Preferences::saveSettings() {
     settings->setValue("informTimestamp",ui->informTimestamp->isChecked());
     settings->setValue("displayCaptions",ui->displayCaptions->currentIndex());
     settings->setValue("legacyStreamDisplay",ui->legacyStreamDisplay->isChecked());
+    settings->setValue("enableFFmpeg",ui->enableFFmpeg->isChecked());
     Sheet::setDefault(ui->comboBoxSheet->itemData(ui->comboBoxSheet->currentIndex()).toInt());
     Sheet::save(settings);
     ConfigTreeText::setDefault(ui->treeTextComboBox->itemData(ui->treeTextComboBox->currentIndex()).toInt());

--- a/Source/GUI/Qt/prefs.ui
+++ b/Source/GUI/Qt/prefs.ui
@@ -167,7 +167,48 @@
        </widget>
        <widget class="QWidget" name="Advanced">
         <layout class="QGridLayout" name="gridLayout_2">
-         <item row="16" column="1">
+         <item row="14" column="0" colspan="2">
+          <widget class="QCheckBox" name="informTimestamp">
+           <property name="text">
+            <string>Add creation date to text output</string>
+           </property>
+          </widget>
+         </item>
+         <item row="12" column="0" colspan="2">
+          <widget class="QCheckBox" name="rememberGeometry">
+           <property name="text">
+            <string>Remember Window Geometry</string>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="0" colspan="2">
+          <widget class="QCheckBox" name="showMenu">
+           <property name="text">
+            <string>Show menu</string>
+           </property>
+          </widget>
+         </item>
+         <item row="19" column="0" colspan="2">
+          <spacer name="verticalSpacer_4">
+           <property name="orientation">
+            <enum>Qt::Orientation::Vertical</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>40</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item row="1" column="0" colspan="2">
+          <widget class="QCheckBox" name="showToolbar">
+           <property name="text">
+            <string>Show toolbar</string>
+           </property>
+          </widget>
+         </item>
+         <item row="17" column="1">
           <widget class="QComboBox" name="displayCaptions">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -195,73 +236,12 @@
            </item>
           </widget>
          </item>
-         <item row="12" column="0" colspan="2">
-          <widget class="QCheckBox" name="rememberGeometry">
-           <property name="text">
-            <string>Remember Window Geometry</string>
-           </property>
-          </widget>
-         </item>
          <item row="0" column="0" colspan="2">
           <widget class="QCheckBox" name="closeAllBeforeOpen">
            <property name="text">
             <string>Close all before open</string>
            </property>
           </widget>
-         </item>
-         <item row="16" column="0">
-          <widget class="QLabel" name="displayCaptions_label">
-           <property name="sizePolicy">
-            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-             <horstretch>0</horstretch>
-             <verstretch>0</verstretch>
-            </sizepolicy>
-           </property>
-           <property name="text">
-            <string>Handling of 608/708 streams:</string>
-           </property>
-          </widget>
-         </item>
-         <item row="11" column="0" colspan="2">
-          <widget class="QCheckBox" name="showMenu">
-           <property name="text">
-            <string>Show menu</string>
-           </property>
-          </widget>
-         </item>
-         <item row="14" column="0" colspan="2">
-          <widget class="QCheckBox" name="informTimestamp">
-           <property name="text">
-            <string>Add creation date to text output</string>
-           </property>
-          </widget>
-         </item>
-         <item row="13" column="0" colspan="2">
-          <widget class="QCheckBox" name="informVersion">
-           <property name="text">
-            <string>Add version to text output</string>
-           </property>
-          </widget>
-         </item>
-         <item row="1" column="0" colspan="2">
-          <widget class="QCheckBox" name="showToolbar">
-           <property name="text">
-            <string>Show toolbar</string>
-           </property>
-          </widget>
-         </item>
-         <item row="17" column="0" colspan="2">
-          <spacer name="verticalSpacer_4">
-           <property name="orientation">
-            <enum>Qt::Orientation::Vertical</enum>
-           </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>20</width>
-             <height>40</height>
-            </size>
-           </property>
-          </spacer>
          </item>
          <item row="6" column="0" rowspan="2" colspan="2">
           <layout class="QHBoxLayout" name="horizontalLayout_3">
@@ -276,6 +256,33 @@
             </widget>
            </item>
           </layout>
+         </item>
+         <item row="13" column="0" colspan="2">
+          <widget class="QCheckBox" name="informVersion">
+           <property name="text">
+            <string>Add version to text output</string>
+           </property>
+          </widget>
+         </item>
+         <item row="17" column="0">
+          <widget class="QLabel" name="displayCaptions_label">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="text">
+            <string>Handling of 608/708 streams:</string>
+           </property>
+          </widget>
+         </item>
+         <item row="16" column="0" colspan="2">
+          <widget class="QCheckBox" name="legacyStreamDisplay">
+           <property name="text">
+            <string>Display legacy AC-3/DTS/AAC streams embedded in HD/HE streams (requires reload)</string>
+           </property>
+          </widget>
          </item>
         </layout>
        </widget>

--- a/Source/GUI/Qt/prefs.ui
+++ b/Source/GUI/Qt/prefs.ui
@@ -167,12 +167,19 @@
        </widget>
        <widget class="QWidget" name="Advanced">
         <layout class="QGridLayout" name="gridLayout_2">
-         <item row="14" column="0" colspan="2">
-          <widget class="QCheckBox" name="informTimestamp">
-           <property name="text">
-            <string>Add creation date to text output</string>
+         <item row="6" column="0" rowspan="2" colspan="2">
+          <layout class="QHBoxLayout" name="horizontalLayout_3">
+           <property name="leftMargin">
+            <number>25</number>
            </property>
-          </widget>
+           <item>
+            <widget class="QCheckBox" name="rememberToolBarPosition">
+             <property name="text">
+              <string>Remember its position</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
          </item>
          <item row="12" column="0" colspan="2">
           <widget class="QCheckBox" name="rememberGeometry">
@@ -181,14 +188,21 @@
            </property>
           </widget>
          </item>
-         <item row="11" column="0" colspan="2">
-          <widget class="QCheckBox" name="showMenu">
+         <item row="14" column="0" colspan="2">
+          <widget class="QCheckBox" name="informTimestamp">
            <property name="text">
-            <string>Show menu</string>
+            <string>Add creation date to text output</string>
            </property>
           </widget>
          </item>
-         <item row="19" column="0" colspan="2">
+         <item row="0" column="0" colspan="2">
+          <widget class="QCheckBox" name="closeAllBeforeOpen">
+           <property name="text">
+            <string>Close all before open</string>
+           </property>
+          </widget>
+         </item>
+         <item row="20" column="0" colspan="2">
           <spacer name="verticalSpacer_4">
            <property name="orientation">
             <enum>Qt::Orientation::Vertical</enum>
@@ -201,6 +215,20 @@
            </property>
           </spacer>
          </item>
+         <item row="16" column="0" colspan="2">
+          <widget class="QCheckBox" name="legacyStreamDisplay">
+           <property name="text">
+            <string>Display legacy AC-3/DTS/AAC streams embedded in HD/HE streams (requires reload)</string>
+           </property>
+          </widget>
+         </item>
+         <item row="11" column="0" colspan="2">
+          <widget class="QCheckBox" name="showMenu">
+           <property name="text">
+            <string>Show menu</string>
+           </property>
+          </widget>
+         </item>
          <item row="1" column="0" colspan="2">
           <widget class="QCheckBox" name="showToolbar">
            <property name="text">
@@ -208,7 +236,7 @@
            </property>
           </widget>
          </item>
-         <item row="17" column="1">
+         <item row="18" column="1">
           <widget class="QComboBox" name="displayCaptions">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -236,35 +264,7 @@
            </item>
           </widget>
          </item>
-         <item row="0" column="0" colspan="2">
-          <widget class="QCheckBox" name="closeAllBeforeOpen">
-           <property name="text">
-            <string>Close all before open</string>
-           </property>
-          </widget>
-         </item>
-         <item row="6" column="0" rowspan="2" colspan="2">
-          <layout class="QHBoxLayout" name="horizontalLayout_3">
-           <property name="leftMargin">
-            <number>25</number>
-           </property>
-           <item>
-            <widget class="QCheckBox" name="rememberToolBarPosition">
-             <property name="text">
-              <string>Remember its position</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </item>
-         <item row="13" column="0" colspan="2">
-          <widget class="QCheckBox" name="informVersion">
-           <property name="text">
-            <string>Add version to text output</string>
-           </property>
-          </widget>
-         </item>
-         <item row="17" column="0">
+         <item row="18" column="0">
           <widget class="QLabel" name="displayCaptions_label">
            <property name="sizePolicy">
             <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -277,10 +277,17 @@
            </property>
           </widget>
          </item>
-         <item row="16" column="0" colspan="2">
-          <widget class="QCheckBox" name="legacyStreamDisplay">
+         <item row="13" column="0" colspan="2">
+          <widget class="QCheckBox" name="informVersion">
            <property name="text">
-            <string>Display legacy AC-3/DTS/AAC streams embedded in HD/HE streams (requires reload)</string>
+            <string>Add version to text output</string>
+           </property>
+          </widget>
+         </item>
+         <item row="17" column="0">
+          <widget class="QCheckBox" name="enableFFmpeg">
+           <property name="text">
+            <string>Enable FFmpeg plugin</string>
            </property>
           </widget>
          </item>

--- a/Source/GUI/Qt/views.cpp
+++ b/Source/GUI/Qt/views.cpp
@@ -23,6 +23,8 @@ QString nameView(ViewMode v) {
        break;
    case VIEW_JSON: return Tr("JSON");
        break;
+   case VIEW_GRAPH: return Tr("Graph");
+       break;
    case VIEW_PBCORE: return Tr("PBCore 1.2");
        break;
    case VIEW_PBCORE2: return Tr("PBCore 2.0");

--- a/Source/GUI/Qt/views.h
+++ b/Source/GUI/Qt/views.h
@@ -17,6 +17,7 @@ typedef enum {
     VIEW_HTML,
     VIEW_XML,
     VIEW_JSON,
+    VIEW_GRAPH,
     VIEW_PBCORE,
     VIEW_PBCORE2,
     VIEW_MPEG7_Strict,


### PR DESCRIPTION
Qt GUI: Revert 'Make Text view editable'
- Revert commit b9fbf9ec8aa9e15bebcc87eb4fe102f47fe56f5f as it broke drag and drop of files into the text view. Text view isn't supposed to be editable anyway so match the wxWidgets version instead of VCL one.

Qt GUI: Add legacy stream display option
- An option that is present in MediaInfoLib and CLI but not yet in the GUI
- Disabled by default

![Screenshot 2024-11-14 204655](https://github.com/user-attachments/assets/a88e0977-be1a-453c-b2a8-2ba6d1129331)

Qt GUI: Enable WithThread so that progress bar actually works
- There is progress bar implemented but it only flashes a split second after MediaInfo appears to hang while opening many files.
- This commit makes the progress bar serve its purpose

![Progress bar](https://github.com/user-attachments/assets/cbed2bdb-d7da-4422-ac38-89be288ab19b)

Qt GUI: Add FFmpeg plugin support
- Tested

![Screenshot 2024-11-15 133957](https://github.com/user-attachments/assets/6721b84f-de3a-49f3-b477-5067e72b688f)

Qt GUI: Add Graph view
- Qt GUI now has working graph view

| Light | Dark |
| - | - |
| ![Screenshot 2024-11-15 155806](https://github.com/user-attachments/assets/f3b8416f-a7f9-4cab-8b63-94681d610a3d) | ![Screenshot 2024-11-15 155853](https://github.com/user-attachments/assets/e3d66491-25ef-491e-bc5d-cb615a40dccd) |

Qt GUI: Add Graph export
- Graph can be exported as SVG