### PR TITLE
Windows GUI: Fixes

### DIFF
--- a/Source/GUI/VCL/GUI_Main.cpp
+++ b/Source/GUI/VCL/GUI_Main.cpp
@@ -1113,7 +1113,6 @@ void __fastcall TMainF::Refresh(TTabSheet *Page)
                     size_t Count=F.Read(Buffer, (size_t)F.Size_Get());
                     if (Count==ZenLib::Error)
                     {
-                        delete[] Buffer; //Buffer=NULL;
                         S1=__T("Unable to load graph template");
                     }
                     else

--- a/Source/GUI/VCL/GUI_Main.dfm
+++ b/Source/GUI/VCL/GUI_Main.dfm
@@ -982,7 +982,6 @@ object MainF: TMainF
         AutoCheck = True
         Caption = 'FIMS 1.3 (beta)'
         RadioItem = True
-        Visible = False
         OnClick = M_View_FIMS_1_3Click
       end
       object M_View_reVTMD: TMenuItem


### PR DESCRIPTION
Fixes for VCL GUI issues that were discovered while working on Qt GUI

- Show FIMS 1.3 in MainMenu
  - FIMS 1.3 was visible everywhere in the VCL GUI (preferences, toolbar, export... ) except in MainMenu -> View
- Fix double free of Buffer for graph template
  - Detected by the static analyzer in Qt when porting the graph view to Qt
