### PR TITLE
Windows GUI: Installer improvements

### DIFF
--- a/Source/Install/MediaInfo_GUI_Windows.nsi
+++ b/Source/Install/MediaInfo_GUI_Windows.nsi
@@ -185,7 +185,7 @@ Section -Post
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "DisplayIcon"     "$INSTDIR\MediaInfo.exe"
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "DisplayVersion"  "${PRODUCT_VERSION}"
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "URLInfoAbout"    "${PRODUCT_WEB_SITE}"
-  Exec 'regsvr32 "$INSTDIR\MediaInfo_InfoTip.dll" /s'
+  ExecWait '"$SYSDIR\regsvr32.exe" "$INSTDIR\MediaInfo_InfoTip.dll" /s'
   !insertmacro MediaInfo_Extensions_Install
 
   ${If} ${AtLeastWin7}
@@ -199,8 +199,7 @@ SectionEnd
 Section Uninstall
   SetRegView 64
   !insertmacro MediaInfo_Extensions_Uninstall
-  Exec 'regsvr32 "$INSTDIR\MediaInfo_InfoTip.dll" /u /s'
-  Sleep 3000
+  ExecWait '"$SYSDIR\regsvr32.exe" "$INSTDIR\MediaInfo_InfoTip.dll" /u /s'
 
   IfFileExists "$INSTDIR\graph_plugin_uninst.exe" 0 +3
     ExecWait '"$INSTDIR\graph_plugin_uninst.exe" /S _?=$INSTDIR'
@@ -213,10 +212,10 @@ Section Uninstall
   !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\MediaInfo.exe"
   !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\MediaInfo.dll"
   !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\MediaInfo_i386.dll"
+  !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\MediaInfo_InfoTip.dll"
   !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\WebView2Loader.dll"
   Delete "$INSTDIR\${PRODUCT_NAME}.url"
   Delete "$INSTDIR\uninst.exe"
-  Delete "$INSTDIR\MediaInfo_InfoTip.dll"
   Delete "$INSTDIR\History.txt"
   Delete "$INSTDIR\License.html"
   Delete "$INSTDIR\License.NoModifications.html"

--- a/Source/Install/MediaInfo_GUI_Windows_i386.nsi
+++ b/Source/Install/MediaInfo_GUI_Windows_i386.nsi
@@ -171,7 +171,7 @@ Section -Post
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "DisplayIcon"     "$INSTDIR\MediaInfo.exe"
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "DisplayVersion"  "${PRODUCT_VERSION}"
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "URLInfoAbout"    "${PRODUCT_WEB_SITE}"
-  Exec 'regsvr32 "$INSTDIR\MediaInfo_InfoTip.dll" /s'
+  ExecWait '"$SYSDIR\regsvr32.exe" "$INSTDIR\MediaInfo_InfoTip.dll" /s'
   !insertmacro MediaInfo_Extensions_Install
 
   ${If} ${AtLeastWin7}
@@ -184,8 +184,7 @@ SectionEnd
 
 Section Uninstall
   !insertmacro MediaInfo_Extensions_Uninstall
-  Exec 'regsvr32 "$INSTDIR\MediaInfo_InfoTip.dll" /u /s'
-  Sleep 3000
+  ExecWait '"$SYSDIR\regsvr32.exe" "$INSTDIR\MediaInfo_InfoTip.dll" /u /s'
 
   IfFileExists "$INSTDIR\graph_plugin_uninst.exe" 0 +3
     ExecWait '"$INSTDIR\graph_plugin_uninst.exe" /S _?=$INSTDIR'
@@ -198,10 +197,10 @@ Section Uninstall
   !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\MediaInfo.exe"
   !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\MediaInfo.dll"
   !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\MediaInfo_i386.dll"
+  !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\MediaInfo_InfoTip.dll"
   !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\WebView2Loader.dll"
   Delete "$INSTDIR\${PRODUCT_NAME}.url"
   Delete "$INSTDIR\uninst.exe"
-  Delete "$INSTDIR\MediaInfo_InfoTip.dll"
   Delete "$INSTDIR\History.txt"
   Delete "$INSTDIR\License.html"
   Delete "$INSTDIR\License.NoModifications.html"

--- a/Source/Install/MediaInfo_GUI_Windows_x64.nsi
+++ b/Source/Install/MediaInfo_GUI_Windows_x64.nsi
@@ -180,7 +180,7 @@ Section -Post
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "DisplayIcon"     "$INSTDIR\MediaInfo.exe"
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "DisplayVersion"  "${PRODUCT_VERSION}"
   WriteRegStr ${PRODUCT_UNINST_ROOT_KEY} "${PRODUCT_UNINST_KEY}" "URLInfoAbout"    "${PRODUCT_WEB_SITE}"
-  Exec 'regsvr32 "$INSTDIR\MediaInfo_InfoTip.dll" /s'
+  ExecWait '"$SYSDIR\regsvr32.exe" "$INSTDIR\MediaInfo_InfoTip.dll" /s'
   !insertmacro MediaInfo_Extensions_Install
 
   ${If} ${AtLeastWin7}
@@ -194,8 +194,7 @@ SectionEnd
 Section Uninstall
   SetRegView 64
   !insertmacro MediaInfo_Extensions_Uninstall
-  Exec 'regsvr32 "$INSTDIR\MediaInfo_InfoTip.dll" /u /s'
-  Sleep 3000
+  ExecWait '"$SYSDIR\regsvr32.exe" "$INSTDIR\MediaInfo_InfoTip.dll" /u /s'
 
   IfFileExists "$INSTDIR\graph_plugin_uninst.exe" 0 +3
     ExecWait '"$INSTDIR\graph_plugin_uninst.exe" /S _?=$INSTDIR'
@@ -208,10 +207,10 @@ Section Uninstall
   !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\MediaInfo.exe"
   !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\MediaInfo.dll"
   !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\MediaInfo_i386.dll"
+  !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\MediaInfo_InfoTip.dll"
   !insertmacro UnInstallLib DLL NOTSHARED REBOOT_NOTPROTECTED "$INSTDIR\WebView2Loader.dll"
   Delete "$INSTDIR\${PRODUCT_NAME}.url"
   Delete "$INSTDIR\uninst.exe"
-  Delete "$INSTDIR\MediaInfo_InfoTip.dll"
   Delete "$INSTDIR\History.txt"
   Delete "$INSTDIR\License.html"
   Delete "$INSTDIR\License.NoModifications.html"


### PR DESCRIPTION
- Use ExecWait for regsvr32 on install to avoid race conditions in case MediaInfo_Extensions_Install writes to same registry.
- Use ExecWait for regsvr32 on uninstall instead of waiting 3000 enabling uninstall to complete faster in most cases.
- Use UnInstallLib DLL to delete MediaInfo_InfoTip.dll on uninstall like with other DLLs to ensure it is cleanly removed after restart if it is still in use by Explorer.