### PR TITLE
Windows GUI: Fix shell extension registries

### DIFF
--- a/Source/Common/Preferences.cpp
+++ b/Source/Common/Preferences.cpp
@@ -867,10 +867,10 @@ int Preferences::ExplorerShell()
                 }
             }
         }
-        ExplorerShell_Edit("SystemFileAssociations\\audio", 0, IsChanged);
-        ExplorerShell_Edit("SystemFileAssociations\\Directory.Audio", 0, IsChanged);
-        ExplorerShell_Edit("SystemFileAssociations\\Directory.Video", 0, IsChanged);
-        ExplorerShell_Edit("SystemFileAssociations\\video", 0, IsChanged);
+        ExplorerShell_Edit("Software\\Classes\\SystemFileAssociations\\audio", 0, IsChanged);
+        ExplorerShell_Edit("Software\\Classes\\SystemFileAssociations\\Directory.Audio", 0, IsChanged);
+        ExplorerShell_Edit("Software\\Classes\\SystemFileAssociations\\Directory.Video", 0, IsChanged);
+        ExplorerShell_Edit("Software\\Classes\\SystemFileAssociations\\video", 0, IsChanged);
 
         //Adding/removing to SystemFileAssociations
         int32s ShellExtension=Config.Read(__T("ShellExtension")).To_int32s();

--- a/Source/Install/MediaInfo_Extensions.nsh
+++ b/Source/Install/MediaInfo_Extensions.nsh
@@ -1,3 +1,10 @@
+!ifndef SHCNE_ASSOCCHANGED
+  !define SHCNE_ASSOCCHANGED 0x08000000
+!endif
+!ifndef SHCNF_IDLIST
+  !define SHCNF_IDLIST 0x0000
+!endif
+
 !macro MediaInfo_Extensions_Install_I Extension
   ; Old InfoTip
   DeleteRegKey HKCR "${Extension}\shellex\{00021500-0000-0000-C000-000000000046}"
@@ -37,10 +44,13 @@
   ; Removing unwanted entries
   !insertmacro MediaInfo_Extensions_Uninstall_I "Directory.Audio"
   !insertmacro MediaInfo_Extensions_Uninstall_I "Directory.Video"
+  !insertmacro MediaInfo_Extensions_Uninstall_I "audio"
+  !insertmacro MediaInfo_Extensions_Uninstall_I "Folder"
+  !insertmacro MediaInfo_Extensions_Uninstall_I "video"
 
   ; directories
   WriteRegStr HKCU "Software\Classes\Directory\Shell\MediaInfo" "Icon" "$INSTDIR\MediaInfo.exe"
-  WriteRegStr HKCU "Software\Classes\Directory\\Shell\MediaInfo\Command" "" "$\"$INSTDIR\MediaInfo.exe$\" $\"%1$\""
+  WriteRegStr HKCU "Software\Classes\Directory\Shell\MediaInfo\Command" "" "$\"$INSTDIR\MediaInfo.exe$\" $\"%1$\""
 
   ; Per item
   !insertmacro MediaInfo_Extensions_Install_I ".264"
@@ -198,9 +208,8 @@
   !insertmacro MediaInfo_Extensions_Install_I ".wvc"
   !insertmacro MediaInfo_Extensions_Install_I ".y4m"
 
-  !insertmacro MediaInfo_Extensions_Install_I "audio"
-  !insertmacro MediaInfo_Extensions_Install_I "Folder"
-  !insertmacro MediaInfo_Extensions_Install_I "video"
+  ; Notify Windows Shell to refresh
+  System::Call 'Shell32::SHChangeNotify(i ${SHCNE_ASSOCCHANGED}, i ${SHCNF_IDLIST}, i 0, i 0)'
 !macroend
 
 !macro MediaInfo_Extensions_Uninstall
@@ -371,7 +380,6 @@
   !insertmacro MediaInfo_Extensions_Uninstall_I ".wvc"
   !insertmacro MediaInfo_Extensions_Uninstall_I ".y4m"
 
-  !insertmacro MediaInfo_Extensions_Uninstall_I "audio"
-  !insertmacro MediaInfo_Extensions_Uninstall_I "Folder"
-  !insertmacro MediaInfo_Extensions_Uninstall_I "video"
+  ; Notify Windows Shell to refresh
+  System::Call 'Shell32::SHChangeNotify(i ${SHCNE_ASSOCCHANGED}, i ${SHCNF_IDLIST}, i 0, i 0)'
 !macroend


### PR DESCRIPTION
Fix bugs to prevent issues such as the following:
https://sourceforge.net/p/mediainfo/support-requests/51/
https://sourceforge.net/p/mediainfo/bugs/1161/ 

Make sure that associations other than for file extensions in MediaInfo's list are properly removed and no longer added.
Also refresh File Explorer's context menu after install/uninstall so changes are visible immediately.

Tests results:
- Context menu entry appears immediately and for both files and folders after install without requiring MediaInfo to be launched first regardless of MediaInfo's existing settings.
- When MediaInfo is launched, context menu is updated according to settings set.
- If shell extension is disabled, context menu entry no longer shows for files associated with audio/video such as .mp3.
- After uninstall, the registry was searched and it was found that some MediaInfo entries still remain. This should be retested after #967 is merged.
