### PR TITLE
Release scripts improvements

### DIFF
--- a/Release/Release_CLI_Windows_i386.bat
+++ b/Release/Release_CLI_Windows_i386.bat
@@ -8,8 +8,8 @@
 
 rem --- Search binaries ---
 set BPATH=
-if exist "%~dp0\..\..\..\MediaArea-Utils-Binaries" set BPATH="%~dp0\..\..\..\MediaArea-Utils-Binaries"
-if exist "%~dp0\..\..\MediaArea-Utils-Binaries" set BPATH="%~dp0\..\..\MediaArea-Utils-Binaries"
+if exist "%~dp0\..\..\..\MediaArea-Utils-Binaries" set "BPATH=%~dp0\..\..\..\MediaArea-Utils-Binaries"
+if exist "%~dp0\..\..\MediaArea-Utils-Binaries" set "BPATH=%~dp0\..\..\MediaArea-Utils-Binaries"
 if "%BPATH%"=="" (
     echo "ERROR: binaries path not found"
     exit /b 1

--- a/Release/Release_CLI_Windows_x64.bat
+++ b/Release/Release_CLI_Windows_x64.bat
@@ -8,8 +8,8 @@
 
 rem --- Search binaries ---
 set BPATH=
-if exist "%~dp0\..\..\..\MediaArea-Utils-Binaries" set BPATH="%~dp0\..\..\..\MediaArea-Utils-Binaries"
-if exist "%~dp0\..\..\MediaArea-Utils-Binaries" set BPATH="%~dp0\..\..\MediaArea-Utils-Binaries"
+if exist "%~dp0\..\..\..\MediaArea-Utils-Binaries" set "BPATH=%~dp0\..\..\..\MediaArea-Utils-Binaries"
+if exist "%~dp0\..\..\MediaArea-Utils-Binaries" set "BPATH=%~dp0\..\..\MediaArea-Utils-Binaries"
 if "%BPATH%"=="" (
     echo "ERROR: binaries path not found"
     exit /b 1

--- a/Release/Release_GUI_Windows_i386.bat
+++ b/Release/Release_GUI_Windows_i386.bat
@@ -8,8 +8,8 @@
 
 rem --- Search binaries ---
 set BPATH=
-if exist "%~dp0\..\..\..\MediaArea-Utils-Binaries" set BPATH="%~dp0\..\..\..\MediaArea-Utils-Binaries"
-if exist "%~dp0\..\..\MediaArea-Utils-Binaries" set BPATH="%~dp0\..\..\MediaArea-Utils-Binaries"
+if exist "%~dp0\..\..\..\MediaArea-Utils-Binaries" set "BPATH=%~dp0\..\..\..\MediaArea-Utils-Binaries"
+if exist "%~dp0\..\..\MediaArea-Utils-Binaries" set "BPATH=%~dp0\..\..\MediaArea-Utils-Binaries"
 if "%BPATH%"=="" (
     echo "ERROR: binaries path not found"
     exit /b 1
@@ -21,9 +21,6 @@ del   MediaInfo_GUI_Windows_i386_WithoutInstaller.7z
 rmdir MediaInfo_GUI_Windows_i386 /S /Q
 mkdir MediaInfo_GUI_Windows_i386
 
-
-@rem --- Preparing ---
-copy BCB\GUI\MediaInfo_GUI.exe BCB\GUI\MediaInfo.exe
 
 @rem --- Copying : Exe ---
 copy  ..\Project\BCB\GUI\Win32\Release\MediaInfo_GUI.exe MediaInfo_GUI_Windows_i386\MediaInfo.exe

--- a/Release/Release_GUI_Windows_x64.bat
+++ b/Release/Release_GUI_Windows_x64.bat
@@ -8,8 +8,8 @@
 
 rem --- Search binaries ---
 set BPATH=
-if exist "%~dp0\..\..\..\MediaArea-Utils-Binaries" set BPATH="%~dp0\..\..\..\MediaArea-Utils-Binaries"
-if exist "%~dp0\..\..\MediaArea-Utils-Binaries" set BPATH="%~dp0\..\..\MediaArea-Utils-Binaries"
+if exist "%~dp0\..\..\..\MediaArea-Utils-Binaries" set "BPATH=%~dp0\..\..\..\MediaArea-Utils-Binaries"
+if exist "%~dp0\..\..\MediaArea-Utils-Binaries" set "BPATH=%~dp0\..\..\MediaArea-Utils-Binaries"
 if "%BPATH%"=="" (
     echo "ERROR: binaries path not found"
     exit /b 1


### PR DESCRIPTION
- Change quotes for `set BPATH` in Windows GUI/CLI release scripts to match what is done in `Release_GUI_Windows.bat`. This prevents failure if the path contains spaces or other characters that can cause issues.
- Remove `Preparing` section from `Release_GUI_Windows_i386.bat` as it is not present in `Release_GUI_Windows_x64.bat` and is not needed. The file that is attempted to copy/rename does not exist including its directory.