### PR TITLE
Windows GUI: Enable high-DPI support for installers

### DIFF
--- a/Source/Install/MediaInfo_GUI_Windows.nsi
+++ b/Source/Install/MediaInfo_GUI_Windows.nsi
@@ -2,6 +2,9 @@
 ; Request application privileges for Windows Vista
 RequestExecutionLevel admin
 
+; Enable high-DPI support
+ManifestDPIAware true
+
 ; Some defines
 !define PRODUCT_NAME "MediaInfo"
 !define PRODUCT_PUBLISHER "MediaArea.net"

--- a/Source/Install/MediaInfo_GUI_Windows_ARM64.nsi
+++ b/Source/Install/MediaInfo_GUI_Windows_ARM64.nsi
@@ -2,6 +2,9 @@
 ; Request application privileges for Windows Vista
 RequestExecutionLevel admin
 
+; Enable high-DPI support
+ManifestDPIAware true
+
 ; Some defines
 !define PRODUCT_NAME "MediaInfo"
 !define PRODUCT_PUBLISHER "MediaArea.net"

--- a/Source/Install/MediaInfo_GUI_Windows_i386.nsi
+++ b/Source/Install/MediaInfo_GUI_Windows_i386.nsi
@@ -2,6 +2,9 @@
 ; Request application privileges for Windows Vista
 RequestExecutionLevel admin
 
+; Enable high-DPI support
+ManifestDPIAware true
+
 ; Some defines
 !define PRODUCT_NAME "MediaInfo"
 !define PRODUCT_PUBLISHER "MediaArea.net"

--- a/Source/Install/MediaInfo_GUI_Windows_x64.nsi
+++ b/Source/Install/MediaInfo_GUI_Windows_x64.nsi
@@ -2,6 +2,9 @@
 ; Request application privileges for Windows Vista
 RequestExecutionLevel admin
 
+; Enable high-DPI support
+ManifestDPIAware true
+
 ; Some defines
 !define PRODUCT_NAME "MediaInfo"
 !define PRODUCT_PUBLISHER "MediaArea.net"


### PR DESCRIPTION
We do not have high-DPI version of `Source\Resource\Image\Windows_Finish.bmp` and NSIS does a poor job of scaling it but at least we no longer have blurry texts.

Before:
<img width="500" alt="Screenshot 2024-12-14 152358" src="https://github.com/user-attachments/assets/e171fe51-db61-4897-a313-89d9e1e22ac0" />

After:
<img width="500" alt="Screenshot 2024-12-14 152501" src="https://github.com/user-attachments/assets/f2ba3717-02be-4854-9220-78abbbc88862" />
