### PR TITLE
Rename shell extension Verb Id

### DIFF
--- a/Source/WindowsQtPackage/AppxManifest.xml
+++ b/Source/WindowsQtPackage/AppxManifest.xml
@@ -31,470 +31,472 @@
       <Extensions>
         <desktop4:Extension Category="windows.fileExplorerContextMenus">
           <desktop4:FileExplorerContextMenus>
+            <!-- Prefix Verb Ids with "C" to work around an OS bug preventing the shell menu from appearing in the
+                 context menu on some machines without it. There is no reason found why it works, but it really does -->
             <desktop5:ItemType Type="Directory">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".264">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".3g2">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".3ga">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".3gp">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".3gpa">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".3gpp">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".aa3">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".aac">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".aacp">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".adts">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ac3">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".act">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".aif">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".aifc">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".aiff">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".amr">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ape">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".asf">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".at3">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".au">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".aud">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".aue">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".avi">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".avif">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".avs">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".bdmv">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".bmp">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".bms">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".braw">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".caf">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".clpi">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dat">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dde">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".divx">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dpg">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dff">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dsd">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dsf">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dts">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dtshd">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dv">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dvr">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dvr-ms">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".eac3">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".evo">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".f4a">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".f4b">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".f4v">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".fla">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".flc">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".fli">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".flac">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".flv">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".gvi">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".gif">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".gis">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".h264">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".h3d">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".hdmov">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".heic">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".heif">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".iamf">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ico">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ifo">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ism">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".isma">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ismv">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".j2k">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".jp2">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".jpeg">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".jpg">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".jps">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".jxl">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m1s">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m1t">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m1v">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m2p">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m2s">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m2t">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m2ts">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m2v">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m4a">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m4b">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m4v">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mac">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mk3d">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mka">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mks">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mkv">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mlp">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mod">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mov">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mp+">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mp2">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mp3">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mp4">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpc">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpd">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpe">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpeg">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpg">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpgv">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpgx">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpls">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpm">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpo">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpv">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mts">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mxf">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".oga">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ogg">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ogm">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ogv">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ogx">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".oma">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".opus">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".png">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".pns">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".qcp">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".qt">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ra">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".rm">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".rmvb">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".shn">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".smv">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".spdif">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".spx">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".stl">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".swf">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".tak">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".thd">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".thd+ac3">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".tif">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".tiff">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".tmf">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".tp">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".trec">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".trp">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ts">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".tta">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ty">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".vob">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".vqf">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".vro">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".w64">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".wav">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".webm">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".webp">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".wma">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".wmv">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".wtv">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".wv">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".wvc">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".y4m">
-              <desktop5:Verb Id="MediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="dea3006d-451d-4f0f-a2b2-c3250cb255b4" />
             </desktop5:ItemType>
           </desktop4:FileExplorerContextMenus>
         </desktop4:Extension>

--- a/Source/WindowsSparsePackage/MSIX/AppxManifest.xml
+++ b/Source/WindowsSparsePackage/MSIX/AppxManifest.xml
@@ -36,470 +36,472 @@
       <Extensions>
         <desktop4:Extension Category="windows.fileExplorerContextMenus">
           <desktop4:FileExplorerContextMenus>
+            <!-- Prefix Verb Ids with "C" to work around an OS bug preventing the shell menu from appearing in the
+                 context menu on some machines without it. There is no reason found why it works, but it really does -->
             <desktop5:ItemType Type="Directory">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".264">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".3g2">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".3ga">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".3gp">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".3gpa">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".3gpp">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".aa3">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".aac">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".aacp">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".adts">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ac3">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".act">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".aif">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".aifc">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".aiff">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".amr">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ape">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".asf">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".at3">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".au">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".aud">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".aue">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".avi">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".avif">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".avs">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".bdmv">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".bmp">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".bms">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".braw">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".caf">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".clpi">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dat">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dde">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".divx">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dpg">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dff">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dsd">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dsf">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dts">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dtshd">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dv">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dvr">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".dvr-ms">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".eac3">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".evo">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".f4a">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".f4b">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".f4v">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".fla">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".flc">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".fli">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".flac">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".flv">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".gvi">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".gif">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".gis">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".h264">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".h3d">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".hdmov">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".heic">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".heif">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".iamf">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ico">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ifo">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ism">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".isma">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ismv">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".j2k">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".jp2">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".jpeg">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".jpg">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".jps">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".jxl">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m1s">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m1t">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m1v">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m2p">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m2s">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m2t">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m2ts">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m2v">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m4a">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m4b">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".m4v">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mac">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mk3d">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mka">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mks">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mkv">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mlp">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mod">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mov">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mp+">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mp2">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mp3">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mp4">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpc">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpd">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpe">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpeg">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpg">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpgv">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpgx">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpls">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpm">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpo">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mpv">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mts">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".mxf">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".oga">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ogg">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ogm">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ogv">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ogx">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".oma">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".opus">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".png">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".pns">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".qcp">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".qt">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ra">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".rm">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".rmvb">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".shn">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".smv">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".spdif">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".spx">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".stl">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".swf">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".tak">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".thd">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".thd+ac3">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".tif">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".tiff">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".tmf">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".tp">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".trec">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".trp">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ts">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".tta">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".ty">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".vob">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".vqf">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".vro">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".w64">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".wav">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".webm">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".webp">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".wma">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".wmv">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".wtv">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".wv">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".wvc">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
             <desktop5:ItemType Type=".y4m">
-              <desktop5:Verb Id="MediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
+              <desktop5:Verb Id="CMediaInfo" Clsid="20669675-b281-4c4f-94fb-cb6fd3995545" />
             </desktop5:ItemType>
           </desktop4:FileExplorerContextMenus>
         </desktop4:Extension>


### PR DESCRIPTION
Workaround Windows issue causing shell extension to not appear in classic context menus on certain systems.
As seen in https://github.com/MediaArea/MediaInfo/issues/994#issuecomment-2541700900 and https://github.com/MediaArea/MediaInfo/issues/994#issuecomment-2541738716.

I have no idea what letter works in our case so let us just try "C" since it worked for NanaZip.

Thanks to https://github.com/M2Team/NanaZip/pull/205.
