### PR TITLE
Fix CI and update README for building Linux GUI on Ubuntu 24.04

### DIFF
--- a/.github/workflows/MediaInfo_Checks.yml
+++ b/.github/workflows/MediaInfo_Checks.yml
@@ -18,7 +18,7 @@ jobs:
         run: |
           if [ "$RUNNER_OS" == "Linux" ]; then
             sudo apt-get update -y
-            sudo apt-get install -y zlib1g-dev libwxgtk3.0-gtk3-dev
+            sudo apt-get install -y zlib1g-dev libwxgtk3.2-dev
           fi
           if [ "$RUNNER_OS" == "macOS" ]; then
             brew install libtool automake wxmac

--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ dpkg -i libmediainfo* libzen*
 *GUI only dependencies*
 
 ```sh
-apt-get install libwxgtk3.0-dev
+apt-get install libwxgtk3.2-dev
 ```
 
 #### Fedora


### PR DESCRIPTION
In Ubuntu 24.04 and newer, `libwxgtk3.2-dev` has replaced older libwxgtk3 versions. Recently, GitHub Actions `ubuntu-latest` runner image has upgraded to Ubuntu 24.04.

This PR updates the GitHub workflow file to fix the failed CI as well as updates the build instructions in README to match.
