### PR TITLE
ShellExt: Handle .url files

### DIFF
--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -429,7 +429,14 @@ void MainWindow::openFiles(QStringList fileNames) {
     //Configuring
     if(fileNames.isEmpty())
         return;
-    for(int i=0;i<fileNames.size();i++) {
+    for (int i = 0; i < fileNames.size(); ++i) {
+        QUrl url(fileNames[i]);
+        if (url.isValid())
+            if (!url.scheme().isEmpty())
+                if (url.scheme().startsWith("http", Qt::CaseInsensitive) ||
+                    url.scheme().startsWith("ftp", Qt::CaseInsensitive) ||
+                    url.scheme().startsWith("sftp", Qt::CaseInsensitive))
+                    continue;
         fileNames[i] = QDir::toNativeSeparators(fileNames[i]);
     }
     C->Menu_File_Open_Files_Begin(settings->value("closeBeforeOpen",true).toBool(), true);

--- a/Source/WindowsShellExtension/pch.h
+++ b/Source/WindowsShellExtension/pch.h
@@ -11,7 +11,9 @@
 #include "framework.h"
 
 #include <filesystem>
+#include <fstream>
 #include <string>
+#include <regex>
 
 #include <strsafe.h>
 


### PR DESCRIPTION
Only works on new Windows 11 context menu. Windows File Explorer's classic context menu does not show any shell extensions for .url files.

[URL files for testing.zip](https://github.com/user-attachments/files/18409714/URL.files.for.testing.zip)
