### PR TITLE
Qt GUI: Make graph plugin work cross-platform

### DIFF
--- a/Source/GUI/Qt/graphplugin.cpp
+++ b/Source/GUI/Qt/graphplugin.cpp
@@ -8,6 +8,7 @@
 #include "ZenLib/Ztring.h"
 #include "ZenLib/File.h"
 #include <QApplication>
+#include <QDir>
 
 #define wstring2QString(_DATA) \
     QString::fromUtf8(Ztring(_DATA).To_UTF8().c_str())
@@ -36,8 +37,9 @@ QString Generate_Graph_HTML(Core *C, QSettings *settings) {
             S1 += (Pos2 ? __T("<br/>") : __T("")) + Svg;
         }
 
-        if (File::Exists(InstallFolder + __T("\\Plugin\\Graph\\Template.html"))) {
-            File F(InstallFolder + __T("\\Plugin\\Graph\\Template.html"));
+        QString template_rel_path = "/Plugin/Graph/Template.html";
+        if (File::Exists(InstallFolder + QString2wstring(QDir::toNativeSeparators(template_rel_path)))) {
+            File F(InstallFolder + QString2wstring(QDir::toNativeSeparators(template_rel_path)));
             int8u *Buffer = new int8u[(size_t)F.Size_Get() + 1];
             size_t Count = F.Read(Buffer, (size_t)F.Size_Get());
             if (Count == ZenLib::Error) {


### PR DESCRIPTION
Good thing I decided to test the graph view on Linux. Turns out a fix is required as I did not think about the backslash previously when porting the code from Windows GUI.

Graph view now confirmed to work in Qt GUI on both Windows and Ubuntu.

Ubuntu screenshots below. Windows still works like previously (https://github.com/MediaArea/MediaInfo/pull/955#issue-2658712002).
![Screenshot from 2025-02-14 01-48-29](https://github.com/user-attachments/assets/b0e13221-47d6-45a2-9138-3388368f37e4)
![Screenshot from 2025-02-14 01-48-51](https://github.com/user-attachments/assets/7a5ab66a-b1f3-4245-b1a7-2d96bab3bd2d)
