### PR TITLE
Improve trace feature in VCL GUI and implement it in Qt GUI

### DIFF
--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -1231,6 +1231,12 @@ void MainWindow::on_actionFull_Parse_toggled(bool checked)
     refreshDisplay();
 }
 
+void MainWindow::on_actionTrace_toggled(bool checked)
+{
+    C->MI->Option_Static(__T("Trace_Level"), checked?__T("1"):__T("0"));
+    ui->menuView->actions().at(VIEW_TEXT)->trigger();
+}
+
 void MainWindow::on_actionClose_All_triggered()
 {
     C->Menu_File_Open_Files_Begin(true);

--- a/Source/GUI/Qt/mainwindow.h
+++ b/Source/GUI/Qt/mainwindow.h
@@ -88,6 +88,7 @@ private slots:
     void on_actionClose_All_triggered();
     void on_actionAdvanced_Mode_toggled(bool);
     void on_actionFull_Parse_toggled(bool);
+    void on_actionTrace_toggled(bool);
     void on_actionExport_triggered();
     void on_actionPreferences_triggered();
     void on_actionKnown_parameters_triggered();

--- a/Source/GUI/Qt/mainwindow.ui
+++ b/Source/GUI/Qt/mainwindow.ui
@@ -77,6 +77,7 @@
     <addaction name="actionAdapt_columns_to_content"/>
     <addaction name="actionAdvanced_Mode"/>
     <addaction name="actionFull_Parse"/>
+    <addaction name="actionTrace"/>
    </widget>
    <widget class="QMenu" name="menuFile">
     <property name="title">
@@ -250,6 +251,14 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+Shift+W</string>
+   </property>
+  </action>
+  <action name="actionTrace">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Trace</string>
    </property>
   </action>
  </widget>

--- a/Source/GUI/VCL/GUI_Main.cpp
+++ b/Source/GUI/VCL/GUI_Main.cpp
@@ -972,14 +972,16 @@ void __fastcall TMainF::Refresh(TTabSheet *Page)
     //Text
     else if (Page==Page_Text)
     {
-        if (M_Debug_Details50->Checked)
-            I->Option_Static(__T("Inform"), __T("Details;0.5"));
-        else if (M_Debug_Details90->Checked)
-            I->Option_Static(__T("Inform"), __T("Details;0.9"));
-        else if (M_Debug_Details100->Checked)
-            I->Option_Static(__T("Inform"), __T("Details;1"));
-        else
-            I->Option_Static(__T("Inform"));
+        I->Option_Static(__T("Inform"));
+
+        if (M_Debug_TraceLevel0->Checked)
+            I->Option_Static(__T("Trace_Level"), __T("0"));
+        else if (M_Debug_TraceLevel50->Checked)
+            I->Option_Static(__T("Trace_Level"), __T("0.5"));
+        else if (M_Debug_TraceLevel90->Checked)
+            I->Option_Static(__T("Trace_Level"), __T("0.9"));
+        else if (M_Debug_TraceLevel100->Checked)
+            I->Option_Static(__T("Trace_Level"), __T("1"));
 
         if (!Prefs->Config(__T("InformVersion")).empty())
             I->Option_Static(__T("Inform_Version"), Prefs->Config(__T("InformVersion")));

--- a/Source/GUI/VCL/GUI_Main.dfm
+++ b/Source/GUI/VCL/GUI_Main.dfm
@@ -1112,28 +1112,28 @@ object MainF: TMainF
       object N7: TMenuItem
         Caption = '-'
       end
-      object M_Debug_Details0: TMenuItem
+      object M_Debug_TraceLevel0: TMenuItem
         AutoCheck = True
-        Caption = 'Details - 0'
+        Caption = 'Trace level - 0'
         Checked = True
         RadioItem = True
         OnClick = M_View_TextClick
       end
-      object M_Debug_Details50: TMenuItem
+      object M_Debug_TraceLevel50: TMenuItem
         AutoCheck = True
-        Caption = 'Details - 5'
+        Caption = 'Trace level - 5'
         RadioItem = True
         OnClick = M_View_TextClick
       end
-      object M_Debug_Details90: TMenuItem
+      object M_Debug_TraceLevel90: TMenuItem
         AutoCheck = True
-        Caption = 'Details - 9'
+        Caption = 'Trace level - 9'
         RadioItem = True
         OnClick = M_View_TextClick
       end
-      object M_Debug_Details100: TMenuItem
+      object M_Debug_TraceLevel100: TMenuItem
         AutoCheck = True
-        Caption = 'Details - 10'
+        Caption = 'Trace level - 10'
         RadioItem = True
         OnClick = M_View_TextClick
       end

--- a/Source/GUI/VCL/GUI_Main.h
+++ b/Source/GUI/VCL/GUI_Main.h
@@ -168,11 +168,11 @@ __published:    // IDE-managed Components
     TLabel *Page_Easy_T3_Codec;
     TButton *Page_Easy_T3_Web;
     TMenuItem *M_Debug_Avanced_More;
-    TMenuItem *M_Debug_Details0;
+    TMenuItem *M_Debug_TraceLevel0;
     TMenuItem *N7;
-    TMenuItem *M_Debug_Details50;
-    TMenuItem *M_Debug_Details90;
-    TMenuItem *M_Debug_Details100;
+    TMenuItem *M_Debug_TraceLevel50;
+    TMenuItem *M_Debug_TraceLevel90;
+    TMenuItem *M_Debug_TraceLevel100;
     TMenuItem *M_NewVersion;
     TMenuItem *M_View_XML;
     TMenuItem *M_View_JSON;


### PR DESCRIPTION
- Windows GUI: Improve trace feature
  - Enable switching back to 'Trace level - 0' after enabling higher levels without restarting MediaInfo.
  - Use newer 'Trace_Level' instead of 'Details'.
  - Rename 'Details' to 'Trace level'.
- Qt GUI: Add trace feature
  - Implement trace feature.
  - Only toggle between level 0 and 1.
  - Screenshot:
    ![Screenshot 2025-02-15 165905](https://github.com/user-attachments/assets/7d23e4d0-314c-47bc-beaf-d2d2056556eb)
