### PR TITLE
Qt GUI: Use Edge WebView2 on Windows

### DIFF
--- a/.github/workflows/MediaInfo-Qt_Checks.yml
+++ b/.github/workflows/MediaInfo-Qt_Checks.yml
@@ -3,12 +3,14 @@ name: MediaInfo-Qt Checks
 on:
   push:
     paths:
+      - '.github/workflows/MediaInfo-Qt_Checks.yml'
       - 'Project/QMake/GUI/**'
       - 'Source/GUI/Qt/**'
       - 'Source/Resource/**'
 
   pull_request:
     paths:
+      - '.github/workflows/MediaInfo-Qt_Checks.yml'
       - 'Project/QMake/GUI/**'
       - 'Source/GUI/Qt/**'
       - 'Source/Resource/**'
@@ -19,7 +21,7 @@ jobs:
     runs-on: windows-latest
     strategy:
       matrix:
-        architecture: [ x64 ]
+        architecture: [ x64, ARM64 ]
       fail-fast: false
     steps:
     - name: Checkout zlib
@@ -41,24 +43,42 @@ jobs:
       uses: actions/checkout@v4
       with:
         path: MediaInfo
-    - name: Set-up Qt
+    - name: Set-up Qt x64
+      if: matrix.architecture == 'x64'
       uses: jurplel/install-qt-action@v4
       with:
         version: 6.8.*
-        modules: 'qtpositioning qtwebchannel qtwebengine'
+        modules: 'qtpositioning qtwebchannel'
+        tools: 'tools_qtcreator,qt.tools.qtcreator'
+    - name: Set-up Qt ARM64
+      if: matrix.architecture == 'ARM64'
+      uses: jurplel/install-qt-action@v4
+      with:
+        arch: 'win64_msvc2022_arm64_cross_compiled'
+        version: 6.8.*
+        modules: 'qtpositioning qtwebchannel'
         tools: 'tools_qtcreator,qt.tools.qtcreator'
     - name: Add msbuild to PATH
       uses: microsoft/setup-msbuild@v2
     - name: Build dependencies
       run: |
         msbuild -t:MediaInfoLib -p:Configuration=Release -p:Platform=${{ matrix.architecture }} -clp:ForceConsoleColor ${{ github.workspace }}\MediaInfoLib\Project\MSVC2022\MediaInfoLib.sln
-        xcopy /y ${{ github.workspace }}\MediaInfoLib\Project\MSVC2022\x64\Release\ZenLib.lib ${{ github.workspace }}\ZenLib\Project\MSVC2022\x64\Release\
-    - name: Build
+        xcopy /y ${{ github.workspace }}\MediaInfoLib\Project\MSVC2022\${{ matrix.architecture }}\Release\ZenLib.lib ${{ github.workspace }}\ZenLib\Project\MSVC2022\${{ matrix.architecture }}\Release\
+    - name: Build x64
+      if: matrix.architecture == 'x64'
       shell: cmd
       run: |
-        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" ${{ matrix.architecture }}
-        qmake.exe ${{ github.workspace }}\MediaInfo\Project\QMake\GUI\MediaInfoQt.pro -spec win32-msvc "CONFIG+=qtquickcompiler" && D:\a\MediaInfo\Qt\Tools\QtCreator\bin\jom\jom.exe qmake_all
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
+        qmake ${{ github.workspace }}\MediaInfo\Project\QMake\GUI\MediaInfoQt.pro -spec win32-msvc "CONFIG+=qtquickcompiler" && D:\a\MediaInfo\Qt\Tools\QtCreator\bin\jom\jom.exe qmake_all
         D:\a\MediaInfo\Qt\Tools\QtCreator\bin\jom\jom.exe
+    - name: Build ARM64
+      if: matrix.architecture == 'ARM64'
+      shell: cmd
+      run: |
+        call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64_arm64
+        qmake ${{ github.workspace }}\MediaInfo\Project\QMake\GUI\MediaInfoQt.pro -spec win32-arm64-msvc "CONFIG+=qtquickcompiler" && D:\a\MediaInfo\Qt\Tools\QtCreator\bin\jom\jom.exe qmake_all
+        D:\a\MediaInfo\Qt\Tools\QtCreator\bin\jom\jom.exe
+
 
   Ubuntu:
     runs-on: ubuntu-latest
@@ -77,7 +97,6 @@ jobs:
         arch: linux_gcc_64
         version: 6.8.*
         modules: 'qtpositioning qtwebchannel qtwebengine'
-        tools: 'tools_qtcreator,qt.tools.qtcreator'
     - name: Build
       run: |
         qmake ${{ github.workspace }}/MediaInfo/Project/QMake/GUI/MediaInfoQt.pro -spec linux-g++ CONFIG+=qtquickcompiler && make qmake_all

--- a/Project/QMake/GUI/MediaInfoQt.pro
+++ b/Project/QMake/GUI/MediaInfoQt.pro
@@ -2,7 +2,10 @@
 # Project created by QtCreator 2010-07-23T13:03:11
 # -------------------------------------------------
 
-QT += core gui widgets network xml webenginewidgets
+QT += core gui widgets network xml
+!win32 {
+    QT += webenginewidgets
+}
 
 win32|macx {
     TARGET = "MediaInfo"
@@ -144,6 +147,8 @@ win32 {
             }
         }
     } else {
+        !build_pass:system("install_nuget_packages.cmd")
+
         contains(QT_ARCH, i386) {
             exists(../../../../MediaInfoLib/Project/MSVC2022/Win32/Release/MediaInfo-Static.lib) {
                 INCLUDEPATH += ../../../../MediaInfoLib/Source
@@ -164,6 +169,13 @@ win32 {
                 LIBS += $$PWD/../../../../zlib/contrib/vstudio/vc17/x86/ZlibStatReleaseWithoutAsm/zlibstat.lib
             } else {
                 error("zlib not found on system")
+            }
+
+            exists(packages/microsoft.web.webview2.1.0.3065.39/build/native/x86/WebView2Loader.dll.lib) {
+                INCLUDEPATH += $$PWD/packages/microsoft.web.webview2.1.0.3065.39/build/native/include
+                LIBS += -L$$PWD/packages/microsoft.web.webview2.1.0.3065.39/build/native/x86 -lWebView2Loader.dll
+            } else {
+                error("Edge WebView2 lib not found on system")
             }
         }
 
@@ -189,6 +201,14 @@ win32 {
                 error("zlib not found on system")
             }
 
+            exists(packages/microsoft.web.webview2.1.0.3065.39/build/native/x64/WebView2Loader.dll.lib) {
+                INCLUDEPATH += $$PWD/packages/microsoft.web.webview2.1.0.3065.39/build/native/include
+                LIBS += -L$$PWD/packages/microsoft.web.webview2.1.0.3065.39/build/native/x64 -lWebView2Loader.dll
+            } else {
+                error("Edge WebView2 lib not found on system")
+            }
+
+
             QMAKE_CXXFLAGS += /guard:ehcont
             QMAKE_LFLAGS += /guard:ehcont
         }
@@ -208,11 +228,18 @@ win32 {
                 error("libzen not found on system")
             }
 
-            exists(../../../../zlib/contrib/vstudio/vc17/ARM64/Release/zlibstat.lib) {
+            exists(../../../../zlib/contrib/vstudio/vc17/arm64/ZlibStatReleaseWithoutAsm/zlibstat.lib) {
                 INCLUDEPATH += ../../../../zlib
-                LIBS += $$PWD/../../../../zlib/contrib/vstudio/vc17/ARM64/ZlibStatReleaseWithoutAsm/zlibstat.lib
+                LIBS += $$PWD/../../../../zlib/contrib/vstudio/vc17/arm64/ZlibStatReleaseWithoutAsm/zlibstat.lib
             } else {
                 error("zlib not found on system")
+            }
+
+            exists(packages/microsoft.web.webview2.1.0.3065.39/build/native/arm64/WebView2Loader.dll.lib) {
+                INCLUDEPATH += $$PWD/packages/microsoft.web.webview2.1.0.3065.39/build/native/include
+                LIBS += -L$$PWD/packages/microsoft.web.webview2.1.0.3065.39/build/native/arm64 -lWebView2Loader.dll
+            } else {
+                error("Edge WebView2 lib not found on system")
             }
 
             QMAKE_CXXFLAGS += /guard:ehcont /guard:signret
@@ -249,6 +276,11 @@ SOURCES += ../../../Source/GUI/Qt/main.cpp \
     ../../../Source/GUI/Qt/configtreetext.cpp \
     ../../../Source/GUI/Qt/editconfigtreetext.cpp
 
+win32 {
+    SOURCES += ../../../Source/GUI/Qt/webview2widget.cpp
+}
+
+
 HEADERS += ../../../Source/GUI/Qt/mainwindow.h \
     ../../../Source/Common/Core.h \
     ../../../Source/GUI/Qt/easyviewwidget.h \
@@ -266,6 +298,10 @@ HEADERS += ../../../Source/GUI/Qt/mainwindow.h \
     ../../../Source/GUI/Qt/translate.h \
     ../../../Source/GUI/Qt/configtreetext.h \
     ../../../Source/GUI/Qt/editconfigtreetext.h
+
+win32 {
+    HEADERS += ../../../Source/GUI/Qt/webview2widget.h
+}
 
 FORMS += ../../../Source/GUI/Qt/mainwindow.ui \
     ../../../Source/GUI/Qt/prefs.ui \

--- a/Project/QMake/GUI/install_nuget_packages.cmd
+++ b/Project/QMake/GUI/install_nuget_packages.cmd
@@ -1,0 +1,4 @@
+if not exist nuget.exe (
+    curl -O https://dist.nuget.org/win-x86-commandline/latest/nuget.exe
+)
+nuget install Microsoft.Web.WebView2 -OutputDirectory packages

--- a/Release/Release_GUI_Qt_Windows_x64_MSIX.cmd
+++ b/Release/Release_GUI_Qt_Windows_x64_MSIX.cmd
@@ -31,7 +31,7 @@ popd
 rmdir /s /q %~dp0\MediaInfo_Qt_Windows_x64
 mkdir %~dp0\MediaInfo_Qt_Windows_x64
 copy %~dp0\..\Project\QMake\GUI\build\Desktop_Qt_%QT_VER2%_MSVC2022_64bit-Release\x64\MediaInfo.exe %~dp0\MediaInfo_Qt_Windows_x64\
-windeployqt --no-quick-import --no-translations --no-system-d3d-compiler --no-compiler-runtime --no-opengl-sw %~dp0\MediaInfo_Qt_Windows_x64\MediaInfo.exe
+windeployqt --no-quick-import --no-translations --no-system-d3d-compiler --no-system-dxc-compiler --no-compiler-runtime --no-opengl-sw %~dp0\MediaInfo_Qt_Windows_x64\MediaInfo.exe
 
 :: clean-up
 rmdir /s /q %~dp0\..\Project\QMake\GUI\build\Desktop_Qt_%QT_VER2%_MSVC2022_64bit-Release
@@ -51,10 +51,14 @@ del /s "%~dp0\MediaInfo_Qt_Windows_x64\msvcp140_codecvt_ids.dll"
 del /s "%~dp0\MediaInfo_Qt_Windows_x64\vcruntime140.dll"
 del /s "%~dp0\MediaInfo_Qt_Windows_x64\vcruntime140_1.dll"
 copy "%~dp0\..\..\MediaArea-Utils-Binaries\Windows\libcurl\x64\Release\LIBCURL.DLL" "%~dp0\MediaInfo_Qt_Windows_x64\"
+copy "%~dp0\..\Project\QMake\GUI\packages\microsoft.web.webview2.1.0.3065.39\build\native\x64\WebView2Loader.dll" "%~dp0\MediaInfo_Qt_Windows_x64\"
 
 :: build and add IExplorerCommand shell extension
-MSBuild /t:Clean;Build /restore "/p:RestorePackagesConfig=true;Configuration=Release Qt;Platform=x64" %~dp0\..\Project\MSVC2022\MediaInfo_WindowsShellExtension\MediaInfo_WindowsShellExtension.vcxproj
+MSBuild /t:Clean;Build "/p:Configuration=Release Qt;Platform=x64" %~dp0\..\Project\MSVC2022\MediaInfo_WindowsShellExtension\MediaInfo_WindowsShellExtension.vcxproj
 copy "%~dp0\..\Project\MSVC2022\MediaInfo_WindowsShellExtension\x64\Release Qt\MediaInfo_WindowsShellExtension.dll" "%~dp0\MediaInfo_Qt_Windows_x64\"
+
+:: sign binaries
+signtool.exe sign /fd SHA256 /a /f %CERT_PATH% /p %CERT_PASS% /tr http://ts.ssl.com /td sha256 %~dp0\MediaInfo_Qt_Windows_x64\MediaInfo.exe %~dp0\MediaInfo_Qt_Windows_x64\MediaInfo_WindowsShellExtension.dll
 
 :: add MSIX manifest and assets
 xcopy %~dp0\..\Source\WindowsQtPackage %~dp0\MediaInfo_Qt_Windows_x64\ /i /e /r /y

--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -32,7 +32,6 @@
 #include <QToolBar>
 #include <QMainWindow>
 #include <QMenuBar>
-#include <QWebEngineView>
 #include <QTranslator>
 #include <QFontDatabase>
 /*
@@ -50,6 +49,14 @@ using namespace ZenLib;
     Ztring().From_UTF8(_DATA.toUtf8())
 
 #define VERSION "24.12"
+
+#if defined(_WIN32)
+#define EDGE_WEBVIEW2_YES
+#include "webview2widget.h"
+#else
+#include <QWebEngineView>
+#endif
+
 #if defined(_WIN32) && defined(WINAPI_FAMILY) && (WINAPI_FAMILY==WINAPI_FAMILY_APP) //UWP Application
 #include <QtPlatformHeaders/QWindowsWindowFunctions>
 #include <ZenLib/Os_Utils.h>
@@ -712,12 +719,22 @@ void MainWindow::refreshDisplay() {
                 break;
             case VIEW_HTML:
                 C->Menu_View_HTML();
-                viewWidget = new QWebEngineView();
-                ((QWebEngineView*)viewWidget)->setHtml(wstring2QString(C->Inform_Get()));
+                #ifdef EDGE_WEBVIEW2_YES
+                    viewWidget = new WebView2Widget();
+                    ((WebView2Widget*)viewWidget)->setHtml(wstring2QString(C->Inform_Get()));
+                #else
+                    viewWidget = new QWebEngineView();
+                    ((QWebEngineView*)viewWidget)->setHtml(wstring2QString(C->Inform_Get()));
+                #endif
                 break;
             case VIEW_GRAPH:
-                viewWidget = new QWebEngineView();
-                ((QWebEngineView*)viewWidget)->setHtml(Generate_Graph_HTML(C, settings));
+                #ifdef EDGE_WEBVIEW2_YES
+                    viewWidget = new WebView2Widget();
+                    ((WebView2Widget*)viewWidget)->setHtml(Generate_Graph_HTML(C, settings));
+                #else
+                    viewWidget = new QWebEngineView();
+                    ((QWebEngineView*)viewWidget)->setHtml(Generate_Graph_HTML(C, settings));
+                #endif
                 break;
             case VIEW_TREE:
                 C->Menu_View_Tree();

--- a/Source/GUI/Qt/webview2widget.cpp
+++ b/Source/GUI/Qt/webview2widget.cpp
@@ -1,0 +1,145 @@
+/*  Copyright (c) MediaArea.net SARL. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
+
+// webview2widget.cpp
+// From code generated with Qwen2.5-Max
+
+#include "webview2widget.h"
+#include <QDebug>
+#include <QResizeEvent>
+#include <QWindow>
+#include <QTimer>
+#include <Shlobj.h>
+#include <WebView2.h>
+#include <windows.h>
+#include <wrl.h>
+
+#pragma comment(lib, "User32.lib")
+
+namespace {
+    std::wstring GetUserDataFolder() {
+        wchar_t appDataPath[MAX_PATH];
+        SHGetFolderPathW(nullptr, CSIDL_LOCAL_APPDATA, nullptr, 0, appDataPath);
+
+        std::wstring userDataFolder = appDataPath;
+        userDataFolder += L"\\mediainfo-gui\\WebView2";
+
+        // Create the folder if it doesn't exist
+        CreateDirectoryW(userDataFolder.c_str(), nullptr);
+
+        return userDataFolder;
+    }
+}
+
+WebView2Widget::WebView2Widget(QWidget *parent)
+    : QWidget(parent), m_hwndHost(nullptr), m_isInitialized(false) {
+    // Set up the widget to host WebView2
+    m_hwndHost = (HWND)this->winId();
+
+    // Initialize WebView2
+    HRESULT hr = InitializeWebView();
+    if (FAILED(hr)) {
+        qWarning() << "Failed to initialize WebView2";
+    }
+}
+
+WebView2Widget::~WebView2Widget() {
+    if (m_webviewController) {
+        m_webviewController->Close();
+    }
+}
+
+HRESULT WebView2Widget::InitializeWebView() {
+    HRESULT hr = CreateCoreWebView2EnvironmentWithOptions(
+        nullptr, GetUserDataFolder().c_str(), nullptr,
+        Microsoft::WRL::Callback<ICoreWebView2CreateCoreWebView2EnvironmentCompletedHandler>(
+            [this](HRESULT result, ICoreWebView2Environment *env) -> HRESULT {
+                                        if (result == S_OK) {
+                                            env->CreateCoreWebView2Controller(
+                                                m_hwndHost,
+                                                Microsoft::WRL::Callback<ICoreWebView2CreateCoreWebView2ControllerCompletedHandler>(
+                                                    [this](HRESULT result, ICoreWebView2Controller *controller) -> HRESULT {
+                                                        Q_UNUSED(result);
+                                                        if (controller != nullptr) {
+                                                            m_webviewController = controller;
+                                                            m_webviewController->get_CoreWebView2(&m_webview);
+
+                                                            RECT bounds;
+                                                            GetClientRect(m_hwndHost, &bounds);
+                                                            m_webviewController->put_Bounds(bounds);
+                                                            m_webviewController->put_IsVisible(TRUE);
+
+                                                            // Mark WebView2 as initialized
+                                                            m_isInitialized = true;
+
+                                                            // Use a single-shot timer to delay resizing until after the widget is properly laid out
+                                                            QTimer::singleShot(0, this, [this]() {
+                                                                resizeEvent(nullptr); // Trigger resizeEvent manually
+                                                            });
+
+                                                            // Process any pending requests
+                                                            ProcessPendingRequests();
+                                                        }
+                                                        return S_OK;
+                                                    }
+                                                ).Get()
+                                            );
+                                        }
+                                        return result;
+                                    }
+        ).Get()
+    );
+
+    return hr;
+}
+
+void WebView2Widget::resizeEvent(QResizeEvent *event) {
+    QWidget::resizeEvent(event);
+
+    if (m_webviewController) {
+        RECT bounds;
+        GetClientRect(m_hwndHost, &bounds);
+        m_webviewController->put_Bounds(bounds);
+    }
+}
+
+void WebView2Widget::ProcessPendingRequests() {
+    // Process pending HTML content
+    while (!m_pendingHtml.isEmpty()) {
+        QString html = m_pendingHtml.dequeue();
+        std::wstring htmlWide = html.toStdWString();
+        m_webview->NavigateToString(htmlWide.c_str());
+    }
+
+    // Process pending URLs
+    while (!m_pendingUrls.isEmpty()) {
+        QUrl url = m_pendingUrls.dequeue();
+        std::wstring urlWide = url.toString().toStdWString();
+        m_webview->Navigate(urlWide.c_str());
+    }
+}
+
+void WebView2Widget::setHtml(const QString &html) {
+    if (m_isInitialized && m_webview) {
+        std::wstring htmlWide = html.toStdWString();
+        m_webview->NavigateToString(htmlWide.c_str());
+    } else {
+        // Queue the HTML content if WebView2 is not yet initialized
+        m_pendingHtml.enqueue(html);
+    }
+}
+
+void WebView2Widget::load(const QUrl &url) {
+    if (m_isInitialized && m_webview) {
+        std::wstring urlWide = url.toString().toStdWString();
+        m_webview->Navigate(urlWide.c_str());
+    } else {
+        // Queue the URL if WebView2 is not yet initialized
+        m_pendingUrls.enqueue(url);
+    }
+}
+
+void WebView2Widget::load(const QString &url) { load(QUrl(url)); }

--- a/Source/GUI/Qt/webview2widget.h
+++ b/Source/GUI/Qt/webview2widget.h
@@ -1,0 +1,51 @@
+/*  Copyright (c) MediaArea.net SARL. All Rights Reserved.
+ *
+ *  Use of this source code is governed by a BSD-style license that can
+ *  be found in the License.html file in the root of the source tree.
+ */
+
+// webview2widget.h
+// From code generated with Qwen2.5-Max
+
+#ifndef WEBVIEW2WIDGET_H
+#define WEBVIEW2WIDGET_H
+
+#include <QQueue>
+#include <QString>
+#include <QUrl>
+#include <QWidget>
+#include <WebView2.h>
+#include <windows.h>
+#include <wrl.h>
+
+class WebView2Widget : public QWidget {
+    Q_OBJECT
+
+public:
+    explicit WebView2Widget(QWidget *parent = nullptr);
+    ~WebView2Widget();
+
+    // Public API: Load HTML content
+    void setHtml(const QString &html);
+
+    // Public API: Load a URL
+    void load(const QUrl &url);
+    void load(const QString &url);
+
+protected:
+    void resizeEvent(QResizeEvent *event) override;
+
+private:
+    HRESULT InitializeWebView();
+    void ProcessPendingRequests();
+
+    HWND m_hwndHost;
+    Microsoft::WRL::ComPtr<ICoreWebView2Controller> m_webviewController;
+    Microsoft::WRL::ComPtr<ICoreWebView2> m_webview;
+
+    bool m_isInitialized;          // Flag to track WebView2 initialization status
+    QQueue<QString> m_pendingHtml; // Queue for pending HTML content
+    QQueue<QUrl> m_pendingUrls;    // Queue for pending URLs
+};
+
+#endif // WEBVIEW2WIDGET_H

--- a/Source/WindowsQtPackage/AppxManifest.xml
+++ b/Source/WindowsQtPackage/AppxManifest.xml
@@ -7,7 +7,8 @@
   xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4"
   xmlns:desktop5="http://schemas.microsoft.com/appx/manifest/desktop/windows10/5"
   xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
-  IgnorableNamespaces="uap rescap desktop desktop4 desktop5 com">
+  xmlns:win32dependencies="http://schemas.microsoft.com/appx/manifest/externaldependencies"  
+  IgnorableNamespaces="uap rescap desktop desktop4 desktop5 com win32dependencies">
   <Identity Name="MediaInfo.Qt" Publisher="CN=MEDIAAREA.NET, O=MEDIAAREA.NET, L=Curienne, S=Auvergne-Rhône-Alpes, C=FR" Version="24.12.0.0" ProcessorArchitecture="x64" />
   <Properties>
     <DisplayName>MediaInfo Qt</DisplayName>
@@ -19,7 +20,8 @@
   </Resources>
   <Dependencies>
     <TargetDeviceFamily Name="Windows.Desktop" MinVersion="10.0.17763.0" MaxVersionTested="10.0.26100.0" />
-    <PackageDependency Name="Microsoft.VCLibs.140.00.UWPDesktop" MinVersion="14.0.24217.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
+    <PackageDependency Name="Microsoft.VCLibs.140.00.UWPDesktop" MinVersion="14.0.33728.0" Publisher="CN=Microsoft Corporation, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" />
+    <win32dependencies:ExternalDependency Name="Microsoft.WebView2" Publisher="CN=Microsoft Windows, O=Microsoft Corporation, L=Redmond, S=Washington, C=US" MinVersion="1.1.1.1" Optional="true" />
   </Dependencies>
   <Capabilities>
     <rescap:Capability Name="runFullTrust" />


### PR DESCRIPTION
It works! :)

I don't know where to put the WebView2 SDK so I just put it in a 'ThirdParty' folder.

The MSIX size after translations and this PR is now around 32MiB. This is with Qt DLLs plus Graph and FFmpeg plugins. May be able to reduce further by removing some unused DLLs (if any remain) or by static linking.

![Screenshot 2025-02-17 192335](https://github.com/user-attachments/assets/e17889ca-8274-425c-9044-680cbd5b5377)

![Screenshot 2025-02-17 192437](https://github.com/user-attachments/assets/0c46e427-0873-4220-bb45-c21fd9cd07a5)
