### PR TITLE
Qt GUI: Font-related fixes

### DIFF
--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -525,10 +525,9 @@ void MainWindow::openDir(QString dirName) {
 }
 
 void MainWindow::refreshDisplay() {
-    QFontDatabase fontDatabase;
     QFont font;
     QFont setMonoFont; setMonoFont.fromString(settings->value("monoFont", "").toString());
-    if (!settings->value("monoFont", "").toString().isEmpty() && fontDatabase.families().contains(setMonoFont.family())) {
+    if (!settings->value("monoFont", "").toString().isEmpty() && QFontDatabase::families().contains(setMonoFont.family())) {
         font = setMonoFont;
     } else {
         QStringList preferredMonoFonts = { "Cascadia Mono", "Mono" };

--- a/Source/GUI/Qt/prefs.cpp
+++ b/Source/GUI/Qt/prefs.cpp
@@ -51,20 +51,17 @@ Preferences::Preferences(QSettings* settings, Core* C, QWidget *parent) :
     }
     ui->comboBox_language->setCurrentIndex(ui->comboBox_language->findData(settings->value("language", "en").toString()));
 
-    QFontDatabase fontDatabase;
     QFont setMonoFont; setMonoFont.fromString(settings->value("monoFont", "").toString());
-    if (!settings->value("monoFont", "").toString().isEmpty() && fontDatabase.families().contains(setMonoFont.family())) {
+    if (!settings->value("monoFont", "").toString().isEmpty() && QFontDatabase::families().contains(setMonoFont.family())) {
         ui->comboBox_font->setCurrentFont(QFont(setMonoFont));
         ui->comboBox_fontSize->setCurrentText(QString::number(setMonoFont.pointSize()));
     } else {
         QStringList preferredMonoFonts = { "Cascadia Mono", "Mono" };
-        for (const QString &fontName : preferredMonoFonts) {
-            if (fontDatabase.families().contains(fontName)) {
-                ui->comboBox_font->setCurrentFont(QFont(fontName));
-                ui->comboBox_fontSize->setCurrentText(QString::number(QFont().pointSize()));
-                break;
-            }
-        }
+        QFont font;
+        font.setFamilies(preferredMonoFonts);
+        font.setStyleHint(QFont::TypeWriter);
+        ui->comboBox_font->setCurrentFont(font);
+        ui->comboBox_fontSize->setCurrentText(QString::number(font.pointSize()));
     }
 
     ui->showMenu->setChecked(settings->value("showMenu",true).toBool());


### PR DESCRIPTION
Some font-related fixes for issues discovered on Ubuntu.
- Fix Preferences not showing the default currently used font correctly when there is no saved setting yet.
- Fix [QFontDatabase deprecated](https://doc.qt.io/qt-6/qfontdatabase-obsolete.html) warning that only appears on Ubuntu Qt Creator but not on Windows Qt Creator.
