### PR TITLE
Update .gitignore for MSVC

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,34 +40,22 @@ Win32
 x64
 My Project
 
-# Visual Studio - Roslyn cache directory
+# Visual Studio 2015+ cache/options directory
 .vs/
 
-# NuGet -------------------------------------------------------------------------------------------
-
-# Ignore NuGet Packages
+# NuGet Packages
 *.nupkg
-
+# NuGet Symbol Packages
+*.snupkg
 # The packages folder can be ignored because of Package Restore
 **/[Pp]ackages/*
-
 # except build/, which is used as an MSBuild target.
 !**/[Pp]ackages/build/
-
 # Uncomment if necessary however generally it will be regenerated when needed
 #!**/[Pp]ackages/repositories.config
-
 # NuGet v3's project.json files produces more ignorable files
 *.nuget.props
 *.nuget.targets
-
-# Ignore other intermediate files that NuGet might create. project.lock.json is used in conjunction
-# with project.json (NuGet v3); project.assets.json is used in conjunction with the PackageReference
-# format (NuGet v4 and .NET Core).
-project.lock.json
-project.assets.json
-
-# -------------------------------------------------------------------------------------------------
 
 # Qt GUI build and translations directories
 /Project/QMake/GUI/build


### PR DESCRIPTION
Tidy/clean-up `.gitignore` and make it consistent with MediaInfoLib for the MSVC section.

Nuget section is now an exact copy from https://github.com/github/gitignore/blob/main/VisualStudio.gitignore
