### PR TITLE
Qt GUI: Fixes for Windows 10

### DIFF
--- a/Source/GUI/Qt/mainwindow.cpp
+++ b/Source/GUI/Qt/mainwindow.cpp
@@ -538,9 +538,9 @@ void MainWindow::refreshDisplay() {
     QFont font;
     if (!settings->value("monoFont", "").toString().isEmpty()) {
         font.fromString(settings->value("monoFont", "").toString());
-        font.setFamilies(QStringList({ font.family(), "Cascadia Mono", "Malgun Gothic", "MS Gothic", "NSimSun", "Mono" }));
+        font.setFamilies(QStringList({ font.family(), "Cascadia Mono", "Courier New", "Malgun Gothic", "MS Gothic", "NSimSun", "Mono" }));
     } else {
-        font.setFamilies(QStringList({ "Cascadia Mono", "Malgun Gothic", "MS Gothic", "NSimSun", "Mono" }));
+        font.setFamilies(QStringList({ "Cascadia Mono", "Courier New", "Malgun Gothic", "MS Gothic", "NSimSun", "Mono" }));
     }
     font.setStyleHint(QFont::TypeWriter);
 

--- a/Source/WindowsQtPackage/AppxManifest.xml
+++ b/Source/WindowsQtPackage/AppxManifest.xml
@@ -31,6 +31,11 @@
          to prevent an OS behaviour causing the application to be forced-closed when File Explorer context menu is loaded. -->
     <Application Id="MediaInfo.Qt" Executable="MediaInfo.exe" EntryPoint="Windows.FullTrustApplication">
       <uap:VisualElements DisplayName="MediaInfo" Description="MediaInfo" BackgroundColor="transparent" Square150x150Logo="Assets\Square150x150Logo.png" Square44x44Logo="Assets\Square44x44Logo.png">
+        <uap:DefaultTile>
+          <uap:ShowNameOnTiles>
+            <uap:ShowOn Tile="square150x150Logo" />
+          </uap:ShowNameOnTiles>
+        </uap:DefaultTile>
       </uap:VisualElements>
       <Extensions>
         <desktop4:Extension Category="windows.fileExplorerContextMenus">


### PR DESCRIPTION
- Enable name display on Windows 10 tile
  - Before and after:
   ![Screenshot 2025-03-23 163641](https://github.com/user-attachments/assets/164775ab-118c-44fd-9a77-7e462a33fc2a) ![Screenshot 2025-03-23 164458](https://github.com/user-attachments/assets/65e48b99-ad7e-41dc-bb05-90eb2ff5c817)
- Fix font selection on Windows when Cascadia Mono in unavailable

Tested that everything is fine on Windows 10 and 11. It also has the correct look/design/theme depending on Windows version.

A test build of MediaInfo Qt GUI in MSIX is available here: https://github.com/cjee21/MediaInfo/actions/runs/14017355671

Since it is unsigned, it can be installed on Windows 11 with the following command in an Administrator PowerShell:
```powershell
Add-AppxPackage -Path MediaInfo_Qt_Windows_x64.msix -AllowUnsigned
```
