### PR TITLE
Qt GUI: Fixes for Qt<6.7 and translations generation

### DIFF
--- a/.github/workflows/MediaInfo-Qt_Checks.yml
+++ b/.github/workflows/MediaInfo-Qt_Checks.yml
@@ -68,12 +68,6 @@ jobs:
         run: |
           msbuild -t:MediaInfoLib -p:Configuration=Release -p:Platform=${{ matrix.architecture }} -clp:ForceConsoleColor ${{ github.workspace }}\MediaInfoLib\Project\MSVC2022\MediaInfoLib.sln
           xcopy /y ${{ github.workspace }}\MediaInfoLib\Project\MSVC2022\${{ matrix.architecture }}\Release\ZenLib.lib ${{ github.workspace }}\ZenLib\Project\MSVC2022\${{ matrix.architecture }}\Release\
-      - name: Generate translations files
-        shell: cmd
-        run: |
-          set PATH=${{ env.QT_ROOT_DIR }}\..\msvc2022_64\bin\;%PATH%
-          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64
-          call ${{ github.workspace }}\MediaInfo\Source\GUI\Qt\Qt_Translations_Updater\update_Qt_translations.cmd
       - name: Build x64
         if: matrix.architecture == 'x64'
         shell: cmd
@@ -85,6 +79,7 @@ jobs:
         if: matrix.architecture == 'ARM64'
         shell: cmd
         run: |
+          set PATH=%PATH%;${{ env.QT_ROOT_DIR }}\..\msvc2022_64\bin\;
           call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\VC\Auxiliary\Build\vcvarsall.bat" x64_arm64
           call qmake.bat ${{ github.workspace }}\MediaInfo\Project\QMake\GUI\MediaInfoQt.pro -spec win32-arm64-msvc "CONFIG+=qtquickcompiler" && ${{ env.IQTA_TOOLS }}\QtCreator\bin\jom\jom.exe qmake_all
           ${{ env.IQTA_TOOLS }}\QtCreator\bin\jom\jom.exe
@@ -108,16 +103,11 @@ jobs:
       - name: Install dependencies
         run: |
           sudo apt-get update -y
-          sudo apt-get install -y zlib1g-dev libgl1-mesa-dev libzen-dev libmediainfo-dev qtchooser qt${{ env.QT_SELECT }}-base-dev qt${{ env.QT_SELECT }}-tools-dev-tools qt${{ env.QT_SELECT }}-webengine-dev
+          sudo apt-get install -y zlib1g-dev libgl1-mesa-dev libzen-dev libmediainfo-dev qtchooser qt${{ env.QT_SELECT }}-base-dev qt${{ env.QT_SELECT }}-svg-dev qt${{ env.QT_SELECT }}-tools-dev-tools qt${{ env.QT_SELECT }}-webengine-dev
           qtchooser -install ${{ env.QT_SELECT }} $(which qmake${{ env.QT_SELECT }})
-      - name: Generate translations files
-        shell: bash
+      - name: Build
         env:
           TERM: linux
-        run: |
-          chmod +x ${{ github.workspace }}/MediaInfo/Source/GUI/Qt/Qt_Translations_Updater/update_Qt_translations.sh
-          ${{ github.workspace }}/MediaInfo/Source/GUI/Qt/Qt_Translations_Updater/update_Qt_translations.sh
-      - name: Build
         run: |
           qmake ${{ github.workspace }}/MediaInfo/Project/QMake/GUI/MediaInfoQt.pro -spec linux-g++ CONFIG+=qtquickcompiler && make qmake_all
           make -j4

--- a/Project/QMake/GUI/MediaInfoQt.pro
+++ b/Project/QMake/GUI/MediaInfoQt.pro
@@ -74,6 +74,14 @@ unix {
     !exists(../../../Source/Resource/Translations/en.ts) {
         system(../../../Source/GUI/Qt/Qt_Translations_Updater/update_Qt_translations.sh)
     }
+
+    UI_FILES = $$files($$PWD/../../../Source/GUI/Qt/*.ui)
+    lessThan(QT_VERSION, 6.7) {
+        for(uiFile, UI_FILES) {
+            system(sed -i 's/Qt::Orientation::Horizontal/Qt::Horizontal/g' $$uiFile)
+            system(sed -i 's/Qt::Orientation::Vertical/Qt::Vertical/g' $$uiFile)
+        }
+    }
 }
 
 win32 {
@@ -257,7 +265,7 @@ win32 {
     }
 
     !exists(../../../Source/Resource/Translations/en.ts) {
-        system(../../../Source/GUI/Qt/Qt_Translations_Updater/update_Qt_translations.bat)
+        system($$PWD/../../../Source/GUI/Qt/Qt_Translations_Updater/update_Qt_translations.cmd)
     }
 }
 

--- a/Release/Release_GUI_Qt_Windows_x64_MSIX.cmd
+++ b/Release/Release_GUI_Qt_Windows_x64_MSIX.cmd
@@ -1,7 +1,7 @@
 :: config
 ::  example:
-::   set QT_PATH=D:\Qt\6.8.2\msvc2022_64
-::   set QT_TOOLS_PATH=D:\Qt\Tools
+::   set QT_PATH=C:\Qt\6.9.0\msvc2022_64
+::   set QT_TOOLS_PATH=C:\Qt\Tools
 ::   set FFMPEG_EXE=%~dp0\..\..\MediaInfo-FFmpeg-Plugin\ffmpeg.exe
 ::   set CERT_PATH=D:\sign_cert.pfx
 ::   set CERT_PASS=K1wdqYSDk0locw6HSSjT
@@ -15,9 +15,6 @@ set CERT_PASS=%CERT_PASS%
 set PATH_TEMP=%PATH%
 set PATH=%QT_PATH%\bin\;%QT_TOOLS_PATH%\QtCreator\bin\jom\;%PATH%
 call "C:\Program Files\Microsoft Visual Studio\2022\Community\VC\Auxiliary\Build\vcvars64.bat"
-
-:: generate/update Qt translations files
-call %~dp0\..\Source\GUI\Qt\Qt_Translations_Updater\update_Qt_translations.cmd
 
 :: build Qt GUI
 rmdir /s /q %~dp0\..\Project\QMake\GUI\build\Desktop_Qt_MSVC2022_64bit-Release

--- a/Source/WindowsQtPackage/AppxManifest.xml
+++ b/Source/WindowsQtPackage/AppxManifest.xml
@@ -2,13 +2,14 @@
 <Package
   xmlns="http://schemas.microsoft.com/appx/manifest/foundation/windows10"
   xmlns:uap="http://schemas.microsoft.com/appx/manifest/uap/windows10"
+  xmlns:uap5="http://schemas.microsoft.com/appx/manifest/uap/windows10/5"
   xmlns:rescap="http://schemas.microsoft.com/appx/manifest/foundation/windows10/restrictedcapabilities"
   xmlns:desktop="http://schemas.microsoft.com/appx/manifest/desktop/windows10"
   xmlns:desktop4="http://schemas.microsoft.com/appx/manifest/desktop/windows10/4"
   xmlns:desktop5="http://schemas.microsoft.com/appx/manifest/desktop/windows10/5"
   xmlns:com="http://schemas.microsoft.com/appx/manifest/com/windows10"
   xmlns:win32dependencies="http://schemas.microsoft.com/appx/manifest/externaldependencies"  
-  IgnorableNamespaces="uap rescap desktop desktop4 desktop5 com win32dependencies">
+  IgnorableNamespaces="uap uap5 rescap desktop desktop4 desktop5 com win32dependencies">
   <Identity Name="MediaInfo.Qt" Publisher="CN=MEDIAAREA.NET, O=MEDIAAREA.NET, L=Curienne, S=Auvergne-Rhône-Alpes, C=FR" Version="25.3.0.0" ProcessorArchitecture="x64" />
   <Properties>
     <DisplayName>MediaInfo Qt</DisplayName>
@@ -38,6 +39,11 @@
         </uap:DefaultTile>
       </uap:VisualElements>
       <Extensions>
+        <uap5:Extension Category="windows.appExecutionAlias" EntryPoint="Windows.FullTrustApplication">
+          <uap5:AppExecutionAlias>
+            <uap5:ExecutionAlias Alias="mediainfo-gui.exe" />
+          </uap5:AppExecutionAlias>
+        </uap5:Extension>
         <desktop4:Extension Category="windows.fileExplorerContextMenus">
           <desktop4:FileExplorerContextMenus>
             <!-- Prefix Verb Ids with "0000" to work around an OS bug preventing the shell menu from appearing in the


### PR DESCRIPTION
Fix Preferences window layout on older Qt versions used by some Linux distros due to change change to fully
qualified enumerations in `.ui` files for newer Qt (https://bugreports.qt.io/browse/QTBUG-126966). This is done by replacing the affected enumerations in `.ui` files when building with older Qt versions.

Some other fixes mainly for translations generation after the changes made in #1081.

Fixed layout on Ubuntu 24.04.2 using repo provided Qt 6.4.2:
![Screenshot from 2025-04-06 22-15-28](https://github.com/user-attachments/assets/3f5d6b16-c86f-4f33-afb3-c2adda8de05c)
