### PR TITLE
Qt GUI: Improve loading of large graphs in Graph view

### DIFF
--- a/Source/GUI/Qt/graphplugin.cpp
+++ b/Source/GUI/Qt/graphplugin.cpp
@@ -8,7 +8,6 @@
 
 #include "graphplugin.h"
 #include "ZenLib/Ztring.h"
-#include "ZenLib/File.h"
 #include <QApplication>
 #include <QComboBox>
 #include <QDir>
@@ -47,43 +46,38 @@ GraphViewWidget::GraphViewWidget(Core *C, QSettings *settings, QWidget *parent)
     refresh();
 }
 
-QString GraphViewWidget::Generate_Graph_HTML() {
-    Ztring S1 = Ztring();
-    Ztring InstallFolder = QString2wstring(QCoreApplication::applicationDirPath());
-    Ztring State = C->Menu_Option_Preferences_Option(__T("Info_Graph_Svg_Plugin_State"), __T(""));
-    if (State == __T("1")) {
-        Ztring Svg = C->MI->Inform(FilePos);
-        size_t SvgBeginPos = Svg.find(__T("<svg"));
-        if (SvgBeginPos != std::string::npos)
-            S1 = Svg.substr(SvgBeginPos);
-        QString template_rel_path = "/Plugin/Graph/Template.html";
-        if (File::Exists(InstallFolder + QString2wstring(QDir::toNativeSeparators(template_rel_path)))) {
-            File F(InstallFolder + QString2wstring(QDir::toNativeSeparators(template_rel_path)));
-            int8u *Buffer = new int8u[(size_t)F.Size_Get() + 1];
-            size_t Count = F.Read(Buffer, (size_t)F.Size_Get());
-            if (Count == ZenLib::Error) {
-                S1 = __T("Unable to load graph template");
-            } else {
-                Buffer[Count] = (int8u)'\0';
-                Ztring Template = Ztring().From_UTF8(reinterpret_cast<char *>(Buffer));
-                if (Template.FindAndReplace(__T("@SVG@"), S1) == 0)
-                    S1 = __T("Invalid template");
+QString GraphViewWidget::generateGraphHTML() {
+    QString html;
+    QString state{wstring2QString(C->Menu_Option_Preferences_Option(__T("Info_Graph_Svg_Plugin_State"), __T("")))};
+    if (state == "1") {
+        QString svg{wstring2QString(C->MI->Inform(FilePos))};
+        auto svgBeginPos{svg.indexOf("<svg")};
+        if (svgBeginPos != -1)
+            svg = svg.mid(svgBeginPos);
+        QFile templateFile(QCoreApplication::applicationDirPath() + QDir::toNativeSeparators("/Plugin/Graph/Template.html"));
+        if (templateFile.exists()) {
+            if (templateFile.open(QIODevice::ReadOnly | QIODevice::Text)) {
+                QTextStream in(&templateFile);
+                QString graphTemplate{in.readAll()};
+                templateFile.close();
+                if (graphTemplate.indexOf("@SVG@") != -1)
+                    html = graphTemplate.replace("@SVG@", svg);
                 else
-                    S1 = Template;
-            }
-            delete[] Buffer;
+                    html = "Invalid template";
+            } else
+                html = "Unable to load graph template";
         } else
-            S1 = __T("Graph template not found");
-    } else if (State == __T("0"))
-        S1 = __T("Graph plugin not installed");
+            html = "Graph template not found";
+    } else if (state == "0")
+        html = "Graph plugin not installed";
     else
-        S1 = State;
+        html = state;
 
-    return wstring2QString(S1);
+    return html;
 }
 
 void GraphViewWidget::refresh() {
-    QString graphHTML = Generate_Graph_HTML();
+    QString graphHTML{generateGraphHTML()};
     if (graphHTML.toUtf8().size() < 0.5e6)
         webView->setHtml(graphHTML);
     else {

--- a/Source/GUI/Qt/graphplugin.cpp
+++ b/Source/GUI/Qt/graphplugin.cpp
@@ -43,6 +43,7 @@ GraphViewWidget::GraphViewWidget(Core *C, QSettings *settings, QWidget *parent)
 
     this->setLayout(layout);
 
+    tempFile.setFileTemplate(tempFile.fileTemplate() + ".html");
     refresh();
 }
 
@@ -82,7 +83,16 @@ QString GraphViewWidget::Generate_Graph_HTML() {
 }
 
 void GraphViewWidget::refresh() {
-    webView->setHtml(Generate_Graph_HTML());
+    QString graphHTML = Generate_Graph_HTML();
+    if (graphHTML.toUtf8().size() < 0.5e6)
+        webView->setHtml(graphHTML);
+    else {
+        if (!tempFile.open())
+            return;
+        tempFile.resize(0);
+        tempFile.write(graphHTML.toUtf8());
+        webView->load(QUrl::fromLocalFile(tempFile.fileName()));
+    }
 }
 
 void GraphViewWidget::changeFilePos(int newFilePos) {

--- a/Source/GUI/Qt/graphplugin.h
+++ b/Source/GUI/Qt/graphplugin.h
@@ -29,7 +29,7 @@ public:
     explicit GraphViewWidget(Core *C, QSettings *settings, QWidget *parent = nullptr);
 
 private:
-    QString Generate_Graph_HTML();
+    QString generateGraphHTML();
     void refresh();
     Core *C;
     int FilePos;

--- a/Source/GUI/Qt/graphplugin.h
+++ b/Source/GUI/Qt/graphplugin.h
@@ -12,6 +12,7 @@
 #include "Common/Core.h"
 #include <QSettings>
 #include <QString>
+#include <QTemporaryFile>
 #include <QWidget>
 
 #ifdef EDGE_WEBVIEW2_YES
@@ -33,6 +34,7 @@ private:
     Core *C;
     int FilePos;
     WebViewWidget *webView;
+    QTemporaryFile tempFile;
 
 signals:
 

--- a/Source/GUI/Qt/webview2widget.h
+++ b/Source/GUI/Qt/webview2widget.h
@@ -37,13 +37,11 @@ protected:
 
 private:
     HRESULT InitializeWebView();
-    void NavigateToString(const std::wstring& html);
     void ProcessPendingRequests();
 
     HWND m_hwndHost;
     Microsoft::WRL::ComPtr<ICoreWebView2Controller> m_webviewController;
     Microsoft::WRL::ComPtr<ICoreWebView2> m_webview;
-    EventRegistrationToken m_navCompletedToken;
 
     bool m_isInitialized;          // Flag to track WebView2 initialization status
     QQueue<QString> m_pendingHtml; // Queue for pending HTML content


### PR DESCRIPTION
Remove the imperfect Edge WebView2 size limitation workaround (#1087).

Use a temporary file for Graph view HTML to ensure large graphs can load and display properly in both Edge WebView2 and Qt WebEngine.

Tested on Windows + Edge WebView2 and Ubuntu + Qt WebEngine.

![Screenshot 2025-04-15 231549](https://github.com/user-attachments/assets/9bd98afd-c3c2-4952-9d2d-38c56e5181b4)
![Screenshot from 2025-04-15 23-16-03](https://github.com/user-attachments/assets/76499622-1575-40da-afe3-1f85e14cabc0)
