### PR TITLE
WX GUI: Fix crash with some wxGTK3 versions

### DIFF
--- a/Source/GUI/WxWidgets/GUI_Main.cpp
+++ b/Source/GUI/WxWidgets/GUI_Main.cpp
@@ -245,6 +245,10 @@ GUI_Main::GUI_Main(int argc, MediaInfoNameSpace::Char** argv_ansi, const wxPoint
 //---------------------------------------------------------------------------
 GUI_Main::~GUI_Main()
 {
+    #ifdef WX_PREFERENCES
+    if (PreferencesEditor)
+        delete PreferencesEditor; //PreferencesEditor=NULL;
+    #endif
     delete C; //C=NULL;
     delete View; //View=NULL;
 }


### PR DESCRIPTION
View_Refresh can be called from the base class destructor.
This causes a silent crash on close before the configuration file is written.

Fixes #1108