### PR TITLE
Qt GUI: Source translations from individual CSVs

### DIFF
--- a/Source/GUI/Qt/Qt_Translations_Updater/README.md
+++ b/Source/GUI/Qt/Qt_Translations_Updater/README.md
@@ -1,6 +1,6 @@
 # Translation Update Script
 
-This folder contains scripts to automate the process of updating Qt `.ts` translation files and generating `.qm` files for MediaInfo's Qt GUI. The process involves using `lupdate` to update the `.ts` files, a Python script to apply custom translations from MediaInfo's `Languages` CSV file, and `lrelease` to generate the final `.qm` files.
+This folder contains scripts to automate the process of updating Qt `.ts` translation files and generating `.qm` files for MediaInfo's Qt GUI. The process involves using `lupdate` to update the `.ts` files, a Python script to apply custom translations from MediaInfo's languages CSV files, and `lrelease` to generate the final `.qm` files.
 
 ## Prerequisites
 
@@ -15,7 +15,7 @@ This Windows Command Script / Unix Shell Script automates the process of updatin
 
 ### `update_Qt_translations.py`
 
-This Python script updates the `.ts` files with translations from the CSV file and handles special cases.
+This Python script updates the `.ts` files with translations from the CSV files and handles special cases.
 
 ## Usage
 
@@ -24,7 +24,7 @@ This Python script updates the `.ts` files with translations from the CSV file a
     - The script will:
       - Delete existing `.ts` and `.qm` files.
       - Run `lupdate` to generate the `.ts` files.
-      - Use `update_Qt_translations.py` to apply translations from `Languages.csv`.
+      - Use `update_Qt_translations.py` to apply translations from `Source\Resource\Plugin\Language\*.csv` files.
       - Run `lrelease` to generate the `.qm` files.
 
 2. **Verify the Output**:

--- a/Source/GUI/Qt/Qt_Translations_Updater/update_Qt_translations.cmd
+++ b/Source/GUI/Qt/Qt_Translations_Updater/update_Qt_translations.cmd
@@ -14,7 +14,7 @@ set RESET=[0m
 REM Set paths
 set PROJECT_FILE=%~dp0\..\..\..\..\Project\QMake\GUI\MediaInfoQt.pro
 set TS_FILES_FOLDER=%~dp0\..\..\..\Resource\Translations
-set CSV_FILE=%~dp0\..\..\..\Resource\Language.csv
+set CSV_DIRECTORY=%~dp0\..\..\..\Resource\Plugin\Language
 set PYTHON_SCRIPT=%~dp0\update_Qt_translations.py
 
 REM Step 0: Delete and recreate the TS_FILES_FOLDER directory
@@ -38,7 +38,7 @@ echo.
 
 REM Step 2: Run the Python script to update .ts files
 echo !YELLOW!Updating .ts files with translations...!RESET!
-python %PYTHON_SCRIPT% %TS_FILES_FOLDER% %CSV_FILE%
+python %PYTHON_SCRIPT% %TS_FILES_FOLDER% %CSV_DIRECTORY%
 if %errorlevel% neq 0 (
     echo.
     echo !RED!Python script failed!%RESET%

--- a/Source/GUI/Qt/Qt_Translations_Updater/update_Qt_translations.sh
+++ b/Source/GUI/Qt/Qt_Translations_Updater/update_Qt_translations.sh
@@ -9,7 +9,7 @@ RESET=$(tput sgr0)
 # Set paths
 PROJECT_FILE=${BASH_SOURCE%/*}/../../../../Project/QMake/GUI/MediaInfoQt.pro
 TS_FILES_FOLDER=${BASH_SOURCE%/*}/../../../Resource/Translations
-CSV_FILE=${BASH_SOURCE%/*}/../../../Resource/Language.csv
+CSV_DIRECTORY=${BASH_SOURCE%/*}/../../../Resource/Plugin/Language
 PYTHON_SCRIPT=${BASH_SOURCE%/*}/update_Qt_translations.py
 
 # Function to print colored messages
@@ -37,7 +37,7 @@ echo
 
 # Step 2: Run the Python script to update .ts files
 print_message "$YELLOW" "Updating .ts files with translations..."
-python3 "$PYTHON_SCRIPT" "$TS_FILES_FOLDER" "$CSV_FILE"
+python3 "$PYTHON_SCRIPT" "$TS_FILES_FOLDER" "$CSV_DIRECTORY"
 if [ $? -ne 0 ]; then
     print_message "$RED" "Python script failed!"
     exit 1


### PR DESCRIPTION
As mentioned at https://github.com/MediaArea/MediaInfo/pull/1141#issuecomment-3140042194, now Qt translations no longer depends on `Languages.csv` so it is safe to be removed.
