### PR TITLE
Android GUI: Migrate to Material Design 3

### DIFF
--- a/.github/workflows/MediaInfo-Android_Checks.yml
+++ b/.github/workflows/MediaInfo-Android_Checks.yml
@@ -1,0 +1,61 @@
+name: MediaInfo-Android Checks
+
+on:
+  push:
+    paths:
+      - '.github/workflows/MediaInfo-Android_Checks.yml'
+      - 'Source/GUI/Android/**'
+
+  pull_request:
+    paths:
+      - '.github/workflows/MediaInfo-Android_Checks.yml'
+      - 'Source/GUI/Android/**'
+
+env:
+  JAVA_VER: 21
+
+jobs:
+
+  Ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout zlib
+        uses: actions/checkout@v4
+        with:
+          repository: MediaArea/zlib
+          path: zlib
+      - name: Checkout ZenLib
+        uses: actions/checkout@v4
+        with:
+          repository: MediaArea/ZenLib
+          path: ZenLib
+      - name: Checkout MediaInfoLib
+        uses: actions/checkout@v4
+        with:
+          repository: MediaArea/MediaInfoLib
+          path: MediaInfoLib
+      - name: Checkout MediaInfo
+        uses: actions/checkout@v4
+        with:
+          repository: MediaArea/MediaInfo
+          path: MediaInfo
+      - name: Build APKs
+        run: |
+          export JAVA_HOME="$JAVA_HOME_${{ env.JAVA_VER }}_X64"
+          pushd ${{ github.workspace }}/MediaInfo/Source/GUI/Android
+          chmod +x gradlew
+          ./gradlew assembleRelease
+          popd
+      - name: Check alignment
+        run: |
+          BUILD_TOOLS=$(ls -d $ANDROID_HOME/build-tools/*/)
+          if [[ -n "$BUILD_TOOLS" ]]; then
+            LATEST_BUILD_TOOLS=$(echo "$BUILD_TOOLS" | sort -Vr | head -n 1)
+            export PATH="$LATEST_BUILD_TOOLS:$PATH"
+            echo "Added $LATEST_BUILD_TOOLS to PATH"
+          else
+            echo "::warning::Check alignment: Android Build Tools directory not found."
+          fi
+          curl "https://android.googlesource.com/platform/system/extras/+/main/tools/check_elf_alignment.sh?format=TEXT"| base64 --decode > check_elf_alignment.sh
+          chmod +x check_elf_alignment.sh
+          ./check_elf_alignment.sh ${{ github.workspace }}/MediaInfo/Source/GUI/Android/app/build/outputs/apk/release/app-universal-release-unsigned.apk

--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,12 @@ My Project
 # Qt GUI build and translations directories
 /Project/QMake/GUI/build
 /Source/Resource/Translations
+
+# Android app directories
+/Source/GUI/Android/.gradle
+/Source/GUI/Android/.idea
+/Source/GUI/Android/app/build
+Source/GUI/Android/app/src/main/res/raw*/lang.csv
+Source/GUI/Android/app/src/main/res/values-*/strings.xml
+/Source/GUI/Android/build
+Source/GUI/Android/local.properties

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 MediaInfo is a convenient unified display of the most relevant technical and tag data for video and audio files.
 
-[![MediaInfo_Checks](https://github.com/MediaArea/MediaInfo/actions/workflows/MediaInfo_Checks.yml/badge.svg)](https://github.com/MediaArea/MediaInfo/actions/workflows/MediaInfo_Checks.yml) [![MediaInfo-Qt Checks](https://github.com/MediaArea/MediaInfo/actions/workflows/MediaInfo-Qt_Checks.yml/badge.svg)](https://github.com/MediaArea/MediaInfo/actions/workflows/MediaInfo-Qt_Checks.yml)
+[![MediaInfo_Checks](https://github.com/MediaArea/MediaInfo/actions/workflows/MediaInfo_Checks.yml/badge.svg)](https://github.com/MediaArea/MediaInfo/actions/workflows/MediaInfo_Checks.yml) [![MediaInfo-Qt Checks](https://github.com/MediaArea/MediaInfo/actions/workflows/MediaInfo-Qt_Checks.yml/badge.svg)](https://github.com/MediaArea/MediaInfo/actions/workflows/MediaInfo-Qt_Checks.yml) [![MediaInfo-Android Checks](https://github.com/MediaArea/MediaInfo/actions/workflows/MediaInfo-Android_Checks.yml/badge.svg)](https://github.com/MediaArea/MediaInfo/actions/workflows/MediaInfo-Android_Checks.yml)
 
 ## About
 

--- a/Source/GUI/Android/app/build.gradle
+++ b/Source/GUI/Android/app/build.gradle
@@ -178,7 +178,7 @@ preBuild.dependsOn copyLocales
 dependencies {
     implementation fileTree(include: ['*.jar'], dir: 'libs')
     implementation 'androidx.multidex:multidex:2.0.1'
-    implementation 'com.google.android.material:material:1.12.0'
+    implementation 'com.google.android.material:material:1.13.0'
     implementation 'androidx.appcompat:appcompat:1.7.1'
     implementation 'androidx.preference:preference-ktx:1.2.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.2.1'
@@ -197,7 +197,7 @@ dependencies {
     implementation 'io.reactivex.rxjava2:rxandroid:2.1.1'
     // Android Lifecycle
     implementation 'androidx.lifecycle:lifecycle-extensions:2.2.0'
-    ksp "androidx.lifecycle:lifecycle-common-java8:2.9.2"
+    ksp "androidx.lifecycle:lifecycle-common-java8:2.9.4"
     // Google Billing
     implementation "com.android.billingclient:billing:8.0.0"
     implementation "com.android.billingclient:billing-ktx:8.0.0"

--- a/Source/GUI/Android/app/src/main/AndroidManifest.xml
+++ b/Source/GUI/Android/app/src/main/AndroidManifest.xml
@@ -22,7 +22,6 @@
 
         <activity
             android:name=".ReportListActivity"
-            android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar"
             android:configChanges="locale|layoutDirection"
             android:exported="true">
@@ -137,7 +136,6 @@
         </activity>
         <activity
             android:name=".ReportDetailActivity"
-            android:label="@string/app_name"
             android:theme="@style/AppTheme.NoActionBar"
             android:configChanges="locale|layoutDirection">
             <meta-data

--- a/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/AboutActivity.kt
+++ b/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/AboutActivity.kt
@@ -10,6 +10,10 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.net.Uri
 import android.content.Intent
+import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import net.mediaarea.mediainfo.databinding.ActivityAboutBinding
 
 class AboutActivity : AppCompatActivity() {
@@ -20,6 +24,25 @@ class AboutActivity : AppCompatActivity() {
 
         activityAboutBinding = ActivityAboutBinding.inflate(layoutInflater)
         setContentView(activityAboutBinding.root)
+
+        ViewCompat.setOnApplyWindowInsetsListener(activityAboutBinding.appBar) { v: View, insets: WindowInsetsCompat ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars()
+                    or WindowInsetsCompat.Type.displayCutout())
+            v.updatePadding(
+                left = bars.left,
+                top = bars.top,
+                right = bars.right,
+            )
+            WindowInsetsCompat.CONSUMED
+        }
+        ViewCompat.setOnApplyWindowInsetsListener(activityAboutBinding.scrollView) { v: View, insets: WindowInsetsCompat ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars()
+                    or WindowInsetsCompat.Type.displayCutout())
+            v.updatePadding(
+                bottom = bars.bottom,
+            )
+            WindowInsetsCompat.CONSUMED
+        }
 
         setSupportActionBar(activityAboutBinding.toolbar)
 

--- a/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/MediaInfoApplication.kt
+++ b/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/MediaInfoApplication.kt
@@ -8,6 +8,7 @@ package net.mediaarea.mediainfo
 
 import android.app.Application
 import androidx.appcompat.app.AppCompatDelegate
+import com.google.android.material.color.DynamicColors
 
 import com.yariksoffice.lingver.Lingver
 import com.yariksoffice.lingver.store.InMemoryLocaleStore
@@ -15,6 +16,8 @@ import com.yariksoffice.lingver.store.InMemoryLocaleStore
 
 class MediaInfoApplication : Application() {
     override fun onCreate() {
+        DynamicColors.applyToActivitiesIfAvailable(this)
+
         super.onCreate()
 
         Lingver.init(this, InMemoryLocaleStore())

--- a/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/ReportDetailActivity.kt
+++ b/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/ReportDetailActivity.kt
@@ -17,6 +17,10 @@ import android.os.Build
 import android.view.MenuItem
 
 import android.content.res.AssetManager
+import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 
 import androidx.viewpager.widget.ViewPager
 
@@ -56,6 +60,25 @@ class ReportDetailActivity : AppCompatActivity(), ReportActivityListener {
 
         activityReportDetailBinding = ActivityReportDetailBinding.inflate(layoutInflater)
         setContentView(activityReportDetailBinding.root)
+
+        ViewCompat.setOnApplyWindowInsetsListener(activityReportDetailBinding.appBar) { v: View, insets: WindowInsetsCompat ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars()
+                    or WindowInsetsCompat.Type.displayCutout())
+            v.updatePadding(
+                left = bars.left,
+                top = bars.top,
+                right = bars.right,
+            )
+            WindowInsetsCompat.CONSUMED
+        }
+        ViewCompat.setOnApplyWindowInsetsListener(activityReportDetailBinding.pager) { v: View, insets: WindowInsetsCompat ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars()
+                    or WindowInsetsCompat.Type.displayCutout())
+            v.updatePadding(
+                bottom = bars.bottom,
+            )
+            WindowInsetsCompat.CONSUMED
+        }
 
         setSupportActionBar(activityReportDetailBinding.detailToolbar)
 

--- a/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/ReportListActivity.kt
+++ b/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/ReportListActivity.kt
@@ -621,7 +621,17 @@ class ReportListActivity : AppCompatActivity(), ReportActivityListener {
         if (activityReportListBinding.reportListLayout.reportDetailContainer != null)
             twoPane = true
 
-         setupRecyclerView(activityReportListBinding.reportListLayout.reportList)
+        if (!twoPane) {
+            val fragment = supportFragmentManager.findFragmentById(R.id.report_detail_container)
+            if (fragment != null) {
+                supportFragmentManager
+                    .beginTransaction()
+                    .detach(fragment)
+                    .commit()
+            }
+        }
+
+        setupRecyclerView(activityReportListBinding.reportListLayout.reportList)
 
         onNewIntent(intent)
     }

--- a/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/ReportListActivity.kt
+++ b/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/ReportListActivity.kt
@@ -35,6 +35,9 @@ import android.content.pm.PackageManager
 import android.content.res.Configuration
 import android.content.res.Resources
 import android.view.*
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 import androidx.preference.PreferenceManager.getDefaultSharedPreferences
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
@@ -534,6 +537,24 @@ class ReportListActivity : AppCompatActivity(), ReportActivityListener {
         activityReportListBinding = ActivityReportListBinding.inflate(layoutInflater)
         helloLayoutBinding = HelloLayoutBinding.inflate(layoutInflater)
 
+        ViewCompat.setOnApplyWindowInsetsListener(activityReportListBinding.appBar) { v: View, insets: WindowInsetsCompat ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars()
+                    or WindowInsetsCompat.Type.displayCutout())
+            v.updatePadding(
+                left = bars.left,
+                top = bars.top,
+                right = bars.right,
+            )
+            WindowInsetsCompat.CONSUMED
+        }
+        ViewCompat.setOnApplyWindowInsetsListener(activityReportListBinding.frameLayout) { v: View, insets: WindowInsetsCompat ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars()
+                    or WindowInsetsCompat.Type.displayCutout())
+            v.updatePadding(
+                bottom = bars.bottom,
+            )
+            WindowInsetsCompat.CONSUMED
+        }
 
         setContentView(activityReportListBinding.root)
 

--- a/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/SettingsActivity.kt
+++ b/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/SettingsActivity.kt
@@ -9,6 +9,10 @@ package net.mediaarea.mediainfo
 import android.content.Context
 import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
+import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 
 import net.mediaarea.mediainfo.databinding.ActivitySettingsBinding
 
@@ -28,6 +32,24 @@ class SettingsActivity : AppCompatActivity(), SettingsActivityListener {
         activitySettingsBinding = ActivitySettingsBinding.inflate(layoutInflater)
         setContentView(activitySettingsBinding.root)
 
+        ViewCompat.setOnApplyWindowInsetsListener(activitySettingsBinding.appBar) { v: View, insets: WindowInsetsCompat ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars()
+                    or WindowInsetsCompat.Type.displayCutout())
+            v.updatePadding(
+                left = bars.left,
+                top = bars.top,
+                right = bars.right,
+            )
+            WindowInsetsCompat.CONSUMED
+        }
+        ViewCompat.setOnApplyWindowInsetsListener(activitySettingsBinding.settingsContainer) { v: View, insets: WindowInsetsCompat ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars()
+                    or WindowInsetsCompat.Type.displayCutout())
+            v.updatePadding(
+                bottom = bars.bottom,
+            )
+            WindowInsetsCompat.CONSUMED
+        }
 
         setSupportActionBar(activitySettingsBinding.toolbar)
 

--- a/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/SubscribeActivity.kt
+++ b/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/SubscribeActivity.kt
@@ -16,6 +16,9 @@ import android.os.Bundle
 import android.view.Gravity
 import android.view.MenuItem
 import android.view.View
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
+import androidx.core.view.updatePadding
 
 import net.mediaarea.mediainfo.databinding.ActivitySubscribeBinding
 
@@ -32,6 +35,25 @@ class SubscribeActivity : AppCompatActivity() {
 
         activitySubscribeBinding = ActivitySubscribeBinding.inflate(layoutInflater)
         setContentView(activitySubscribeBinding.root)
+
+        ViewCompat.setOnApplyWindowInsetsListener(activitySubscribeBinding.appBar) { v: View, insets: WindowInsetsCompat ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars()
+                    or WindowInsetsCompat.Type.displayCutout())
+            v.updatePadding(
+                left = bars.left,
+                top = bars.top,
+                right = bars.right,
+            )
+            WindowInsetsCompat.CONSUMED
+        }
+        ViewCompat.setOnApplyWindowInsetsListener(activitySubscribeBinding.scrollView) { v: View, insets: WindowInsetsCompat ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars()
+                    or WindowInsetsCompat.Type.displayCutout())
+            v.updatePadding(
+                bottom = bars.bottom,
+            )
+            WindowInsetsCompat.CONSUMED
+        }
 
         subscriptionManager = SubscriptionManager.getInstance(application)
 

--- a/Source/GUI/Android/app/src/main/res/layout/activity_about.xml
+++ b/Source/GUI/Android/app/src/main/res/layout/activity_about.xml
@@ -16,16 +16,14 @@
     tools:context=".AboutActivity">
 
     <com.google.android.material.appbar.AppBarLayout
+        android:background="?attr/colorSurfaceContainer"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:theme="@style/AppTheme.AppBarOverlay">
+        android:layout_height="wrap_content">
 
-        <androidx.appcompat.widget.Toolbar
+        <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:background="?attr/colorPrimary"
-            app:popupTheme="@style/AppTheme.PopupOverlay" />
+            android:layout_height="?attr/actionBarSize" />
 
     </com.google.android.material.appbar.AppBarLayout>
 
@@ -91,17 +89,17 @@
                 android:id="@+id/website_btn"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textColor="@color/colorPrimary"
                 android:text="@string/website_text"
-                style="@style/Widget.AppCompat.Button.Borderless"/>
+                android:textAllCaps="true"
+                style="@style/Widget.Material3.Button.TextButton"/>
 
             <Button
                 android:id="@+id/email_btn"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textColor="@color/colorPrimary"
                 android:text="@string/email_text"
-                style="@style/Widget.AppCompat.Button.Borderless"/>
+                android:textAllCaps="true"
+                style="@style/Widget.Material3.Button.TextButton"/>
 
         </LinearLayout>
 

--- a/Source/GUI/Android/app/src/main/res/layout/activity_about.xml
+++ b/Source/GUI/Android/app/src/main/res/layout/activity_about.xml
@@ -17,8 +17,10 @@
 
     <com.google.android.material.appbar.AppBarLayout
         android:background="?attr/colorSurfaceContainer"
+        android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
@@ -27,82 +29,89 @@
 
     </com.google.android.material.appbar.AppBarLayout>
 
-    <androidx.constraintlayout.widget.ConstraintLayout
+    <ScrollView
+        android:id="@+id/scroll_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
 
-        <ImageView
-            android:id="@+id/app_icon"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_marginEnd="8dp"
-            android:layout_marginStart="8dp"
-            android:layout_marginTop="8dp"
-            android:adjustViewBounds="false"
-            android:contentDescription="@string/logo_desc"
-            app:layout_constraintEnd_toEndOf="parent"
-            app:layout_constraintStart_toStartOf="parent"
-            app:layout_constraintTop_toTopOf="parent"
-            app:srcCompat="@mipmap/ic_launcher_foreground" />
+        <androidx.constraintlayout.widget.ConstraintLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content">
 
-        <TextView
-            android:id="@+id/about_about_textview"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/text_margin"
-            android:text="@string/about_about_text"
-            android:textAlignment="center"
-            app:layout_constraintTop_toBottomOf="@+id/app_icon"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent" />
-        <TextView
-            android:id="@+id/about_copyright_textview"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/text_margin"
-            android:text="@string/about_copyright_text"
-            android:textAlignment="center"
-            app:layout_constraintTop_toBottomOf="@+id/about_about_textview"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent" />
-        <TextView
-            android:id="@+id/about_description_textview"
-            android:layout_width="0dp"
-            android:layout_height="wrap_content"
-            android:layout_margin="@dimen/text_margin"
-            android:text="@string/about_description_text"
-            android:textAlignment="center"
-            app:layout_constraintTop_toBottomOf="@+id/about_copyright_textview"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent" />
-
-        <LinearLayout
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:orientation="horizontal"
-            app:layout_constraintTop_toBottomOf="@+id/about_description_textview"
-            app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent" >
-
-            <Button
-                android:id="@+id/website_btn"
+            <ImageView
+                android:id="@+id/app_icon"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/website_text"
-                android:textAllCaps="true"
-                style="@style/Widget.Material3.Button.TextButton"/>
+                android:layout_marginEnd="8dp"
+                android:layout_marginStart="8dp"
+                android:layout_marginTop="8dp"
+                android:adjustViewBounds="false"
+                android:contentDescription="@string/logo_desc"
+                app:layout_constraintEnd_toEndOf="parent"
+                app:layout_constraintStart_toStartOf="parent"
+                app:layout_constraintTop_toTopOf="parent"
+                app:srcCompat="@mipmap/ic_launcher_foreground" />
 
-            <Button
-                android:id="@+id/email_btn"
+            <TextView
+                android:id="@+id/about_about_textview"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/text_margin"
+                android:text="@string/about_about_text"
+                android:textAlignment="center"
+                app:layout_constraintTop_toBottomOf="@+id/app_icon"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent" />
+            <TextView
+                android:id="@+id/about_copyright_textview"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/text_margin"
+                android:text="@string/about_copyright_text"
+                android:textAlignment="center"
+                app:layout_constraintTop_toBottomOf="@+id/about_about_textview"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent" />
+            <TextView
+                android:id="@+id/about_description_textview"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_margin="@dimen/text_margin"
+                android:text="@string/about_description_text"
+                android:textAlignment="center"
+                app:layout_constraintTop_toBottomOf="@+id/about_copyright_textview"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent" />
+
+            <LinearLayout
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:text="@string/email_text"
-                android:textAllCaps="true"
-                style="@style/Widget.Material3.Button.TextButton"/>
+                android:orientation="horizontal"
+                app:layout_constraintTop_toBottomOf="@+id/about_description_textview"
+                app:layout_constraintLeft_toLeftOf="parent"
+                app:layout_constraintRight_toRightOf="parent">
 
-        </LinearLayout>
+                <Button
+                    android:id="@+id/website_btn"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/website_text"
+                    android:textAllCaps="true"
+                    style="@style/Widget.Material3.Button.TextButton" />
 
-    </androidx.constraintlayout.widget.ConstraintLayout>
+                <Button
+                    android:id="@+id/email_btn"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/email_text"
+                    android:textAllCaps="true"
+                    style="@style/Widget.Material3.Button.TextButton" />
+
+            </LinearLayout>
+
+        </androidx.constraintlayout.widget.ConstraintLayout>
+
+    </ScrollView>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Source/GUI/Android/app/src/main/res/layout/activity_report_detail.xml
+++ b/Source/GUI/Android/app/src/main/res/layout/activity_report_detail.xml
@@ -8,7 +8,6 @@
 
 <LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
@@ -18,16 +17,14 @@
     tools:ignore="MergeRootFrame">
 
     <com.google.android.material.appbar.AppBarLayout
+        android:background="?attr/colorSurfaceContainer"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:theme="@style/AppTheme.AppBarOverlay">
+        android:layout_height="wrap_content">
 
-        <androidx.appcompat.widget.Toolbar
+        <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/detail_toolbar"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:background="?attr/colorPrimary"
-            app:popupTheme="@style/AppTheme.PopupOverlay" />
+            android:layout_height="?attr/actionBarSize" />
 
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/Source/GUI/Android/app/src/main/res/layout/activity_report_detail.xml
+++ b/Source/GUI/Android/app/src/main/res/layout/activity_report_detail.xml
@@ -6,20 +6,22 @@
       be found in the License.html file in the root of the source tree.
 -->
 
-<LinearLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
+    xmlns:app="http://schemas.android.com/apk/res-auto"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-    android:orientation="vertical"
     tools:context=".ReportDetailActivity"
     tools:ignore="MergeRootFrame">
 
     <com.google.android.material.appbar.AppBarLayout
         android:background="?attr/colorSurfaceContainer"
+        android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/detail_toolbar"
@@ -31,7 +33,8 @@
     <androidx.viewpager.widget.ViewPager
         android:id="@+id/pager"
         android:layout_width="match_parent"
-        android:layout_height="0dp"
-        android:layout_weight="3" />
+        android:layout_height="match_parent"
+        android:layout_weight="3"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
 
-</LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Source/GUI/Android/app/src/main/res/layout/activity_report_list.xml
+++ b/Source/GUI/Android/app/src/main/res/layout/activity_report_list.xml
@@ -16,16 +16,15 @@
     tools:context=".ReportListActivity">
 
     <com.google.android.material.appbar.AppBarLayout
+        android:background="?attr/colorSurfaceContainer"
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:theme="@style/AppTheme.AppBarOverlay">
+        android:layout_height="wrap_content">
 
-        <androidx.appcompat.widget.Toolbar
+        <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/tool_bar"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            app:popupTheme="@style/AppTheme.PopupOverlay" />
+            android:layout_height="?attr/actionBarSize" />
 
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/Source/GUI/Android/app/src/main/res/layout/activity_report_list.xml
+++ b/Source/GUI/Android/app/src/main/res/layout/activity_report_list.xml
@@ -19,7 +19,8 @@
         android:background="?attr/colorSurfaceContainer"
         android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/tool_bar"

--- a/Source/GUI/Android/app/src/main/res/layout/activity_settings.xml
+++ b/Source/GUI/Android/app/src/main/res/layout/activity_settings.xml
@@ -6,20 +6,21 @@
       be found in the License.html file in the root of the source tree.
 -->
 
-<LinearLayout
+<androidx.coordinatorlayout.widget.CoordinatorLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
-    android:layout_height="wrap_content"
+    android:layout_height="match_parent"
     android:fitsSystemWindows="true"
-    android:orientation="vertical"
     tools:context=".SettingsActivity">
 
    <com.google.android.material.appbar.AppBarLayout
        android:background="?attr/colorSurfaceContainer"
-        android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+       android:id="@+id/app_bar"
+       android:layout_width="match_parent"
+       android:layout_height="wrap_content"
+       android:fitsSystemWindows="true">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
@@ -31,6 +32,7 @@
     <FrameLayout
         android:id="@+id/settings_container"
         android:layout_width="match_parent"
-        android:layout_height="match_parent" />
+        android:layout_height="match_parent"
+        app:layout_behavior="@string/appbar_scrolling_view_behavior"/>
 
-</LinearLayout>
+</androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Source/GUI/Android/app/src/main/res/layout/activity_settings.xml
+++ b/Source/GUI/Android/app/src/main/res/layout/activity_settings.xml
@@ -17,16 +17,14 @@
     tools:context=".SettingsActivity">
 
    <com.google.android.material.appbar.AppBarLayout
+       android:background="?attr/colorSurfaceContainer"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:theme="@style/AppTheme.AppBarOverlay">
+        android:layout_height="wrap_content">
 
-        <androidx.appcompat.widget.Toolbar
+        <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:background="?attr/colorPrimary"
-            app:popupTheme="@style/AppTheme.PopupOverlay"/>
+            android:layout_height="?attr/actionBarSize" />
 
     </com.google.android.material.appbar.AppBarLayout>
 

--- a/Source/GUI/Android/app/src/main/res/layout/activity_subscribe.xml
+++ b/Source/GUI/Android/app/src/main/res/layout/activity_subscribe.xml
@@ -17,8 +17,10 @@
 
     <com.google.android.material.appbar.AppBarLayout
         android:background="?attr/colorSurfaceContainer"
+        android:id="@+id/app_bar"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content">
+        android:layout_height="wrap_content"
+        android:fitsSystemWindows="true">
 
         <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
@@ -28,6 +30,7 @@
     </com.google.android.material.appbar.AppBarLayout>
 
     <ScrollView
+        android:id="@+id/scroll_view"
         android:layout_width="match_parent"
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior"

--- a/Source/GUI/Android/app/src/main/res/layout/activity_subscribe.xml
+++ b/Source/GUI/Android/app/src/main/res/layout/activity_subscribe.xml
@@ -16,16 +16,14 @@
     tools:context=".SubscribeActivity">
 
     <com.google.android.material.appbar.AppBarLayout
+        android:background="?attr/colorSurfaceContainer"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:theme="@style/AppTheme.AppBarOverlay">
+        android:layout_height="wrap_content">
 
-        <androidx.appcompat.widget.Toolbar
+        <com.google.android.material.appbar.MaterialToolbar
             android:id="@+id/toolbar"
             android:layout_width="match_parent"
-            android:layout_height="?attr/actionBarSize"
-            android:background="?attr/colorPrimary"
-            app:popupTheme="@style/AppTheme.PopupOverlay" />
+            android:layout_height="?attr/actionBarSize" />
 
     </com.google.android.material.appbar.AppBarLayout>
 
@@ -58,9 +56,7 @@
                 android:layout_marginTop="10dp"
                 android:layout_marginBottom="10dp"
                 android:text="@string/subscribe_button_text"
-                android:enabled="false"
-                android:textColor="@android:color/white"
-                android:background="@color/colorPrimary" />
+                android:enabled="false" />
 
             <TextView
                 android:id="@+id/subscription_detail_text"
@@ -85,9 +81,7 @@
                 android:layout_marginTop="10dp"
                 android:layout_marginBottom="10dp"
                 android:text="@string/lifetime_subscribe_button_text"
-                android:enabled="false"
-                android:textColor="@android:color/white"
-                android:background="@color/colorPrimary" />
+                android:enabled="false" />
 
             <View
                 android:layout_width="match_parent"

--- a/Source/GUI/Android/app/src/main/res/menu/menu_detail.xml
+++ b/Source/GUI/Android/app/src/main/res/menu/menu_detail.xml
@@ -14,6 +14,7 @@
         android:id="@+id/action_export_report"
         android:icon="@drawable/ic_menu_export"
         android:title="@string/menu_export"
+        app:iconTint="?attr/colorOnSurfaceVariant"
         app:showAsAction="always">
     </item>
 
@@ -21,6 +22,7 @@
         android:id="@+id/action_change_view"
         android:icon="@drawable/ic_menu_view"
         android:title="@string/menu_views"
+        app:iconTint="?attr/colorOnSurfaceVariant"
         app:showAsAction="ifRoom">
             <menu android:id="@+id/menu_views">
                 <group android:id="@+id/menu_views_group" />

--- a/Source/GUI/Android/app/src/main/res/values-night/colors.xml
+++ b/Source/GUI/Android/app/src/main/res/values-night/colors.xml
@@ -7,9 +7,54 @@
 -->
 
 <resources>
-    <color name="colorPrimary">#283593</color>
-    <color name="colorPrimaryDark">#1A237E</color>
-    <color name="colorAccent">#283593</color>
     <color name="background">#212121</color>
     <color name="foreground">#FFFFFF</color>
+
+    <color name="md_theme_primary">#BAC3FF</color>
+    <color name="md_theme_onPrimary">#08218A</color>
+    <color name="md_theme_primaryContainer">#3F51B5</color>
+    <color name="md_theme_onPrimaryContainer">#CACFFF</color>
+    <color name="md_theme_secondary">#BEC4F2</color>
+    <color name="md_theme_onSecondary">#272E53</color>
+    <color name="md_theme_secondaryContainer">#3E446B</color>
+    <color name="md_theme_onSecondaryContainer">#ADB2DF</color>
+    <color name="md_theme_tertiary">#FFA9FD</color>
+    <color name="md_theme_onTertiary">#58055F</color>
+    <color name="md_theme_tertiaryContainer">#893A8D</color>
+    <color name="md_theme_onTertiaryContainer">#FFBDFB</color>
+    <color name="md_theme_error">#FFB4AB</color>
+    <color name="md_theme_onError">#690005</color>
+    <color name="md_theme_errorContainer">#93000A</color>
+    <color name="md_theme_onErrorContainer">#FFDAD6</color>
+    <color name="md_theme_background">#121319</color>
+    <color name="md_theme_onBackground">#E3E1EA</color>
+    <color name="md_theme_surface">#121319</color>
+    <color name="md_theme_onSurface">#E3E1EA</color>
+    <color name="md_theme_surfaceVariant">#454652</color>
+    <color name="md_theme_onSurfaceVariant">#C5C5D4</color>
+    <color name="md_theme_outline">#8F909E</color>
+    <color name="md_theme_outlineVariant">#454652</color>
+    <color name="md_theme_scrim">#000000</color>
+    <color name="md_theme_inverseSurface">#E3E1EA</color>
+    <color name="md_theme_inverseOnSurface">#2F3037</color>
+    <color name="md_theme_inversePrimary">#4355B9</color>
+    <color name="md_theme_primaryFixed">#DEE0FF</color>
+    <color name="md_theme_onPrimaryFixed">#00105C</color>
+    <color name="md_theme_primaryFixedDim">#BAC3FF</color>
+    <color name="md_theme_onPrimaryFixedVariant">#293CA0</color>
+    <color name="md_theme_secondaryFixed">#DEE0FF</color>
+    <color name="md_theme_onSecondaryFixed">#12183D</color>
+    <color name="md_theme_secondaryFixedDim">#BEC4F2</color>
+    <color name="md_theme_onSecondaryFixedVariant">#3E446B</color>
+    <color name="md_theme_tertiaryFixed">#FFD6FA</color>
+    <color name="md_theme_onTertiaryFixed">#37003C</color>
+    <color name="md_theme_tertiaryFixedDim">#FFA9FD</color>
+    <color name="md_theme_onTertiaryFixedVariant">#722578</color>
+    <color name="md_theme_surfaceDim">#121319</color>
+    <color name="md_theme_surfaceBright">#383940</color>
+    <color name="md_theme_surfaceContainerLowest">#0D0E14</color>
+    <color name="md_theme_surfaceContainerLow">#1A1B22</color>
+    <color name="md_theme_surfaceContainer">#1F1F26</color>
+    <color name="md_theme_surfaceContainerHigh">#292930</color>
+    <color name="md_theme_surfaceContainerHighest">#34343B</color>
 </resources>

--- a/Source/GUI/Android/app/src/main/res/values-v23/styles.xml
+++ b/Source/GUI/Android/app/src/main/res/values-v23/styles.xml
@@ -1,0 +1,14 @@
+<!--  Copyright (c) MediaArea.net SARL. All Rights Reserved.
+
+      Use of this source code is governed by a BSD-style license that can
+      be found in the License.html file in the root of the source tree.
+-->
+
+<resources>
+    <style name="AppTheme" parent="BaseTheme">
+        <!-- Transparent system bars for edge-to-edge. -->
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowLightStatusBar">?attr/isLightTheme</item>
+    </style>
+</resources>

--- a/Source/GUI/Android/app/src/main/res/values-v27/styles.xml
+++ b/Source/GUI/Android/app/src/main/res/values-v27/styles.xml
@@ -1,0 +1,15 @@
+<!--  Copyright (c) MediaArea.net SARL. All Rights Reserved.
+
+      Use of this source code is governed by a BSD-style license that can
+      be found in the License.html file in the root of the source tree.
+-->
+
+<resources>
+    <style name="AppTheme" parent="BaseTheme">
+        <!-- Transparent system bars for edge-to-edge. -->
+        <item name="android:navigationBarColor">@android:color/transparent</item>
+        <item name="android:statusBarColor">@android:color/transparent</item>
+        <item name="android:windowLightNavigationBar">?attr/isLightTheme</item>
+        <item name="android:windowLightStatusBar">?attr/isLightTheme</item>
+    </style>
+</resources>

--- a/Source/GUI/Android/app/src/main/res/values/colors.xml
+++ b/Source/GUI/Android/app/src/main/res/values/colors.xml
@@ -8,9 +8,54 @@
 
 <resources>
     <color name="ic_launcher_background">#FFFFFF</color>
-    <color name="colorPrimary">#3F51B5</color>
-    <color name="colorPrimaryDark">#303F9F</color>
-    <color name="colorAccent">#3949AB</color>
     <color name="background">#FFFFFF</color>
     <color name="foreground">#000000</color>
+
+    <color name="md_theme_primary">#24389C</color>
+    <color name="md_theme_onPrimary">#FFFFFF</color>
+    <color name="md_theme_primaryContainer">#3F51B5</color>
+    <color name="md_theme_onPrimaryContainer">#CACFFF</color>
+    <color name="md_theme_secondary">#565C84</color>
+    <color name="md_theme_onSecondary">#FFFFFF</color>
+    <color name="md_theme_secondaryContainer">#C9CFFD</color>
+    <color name="md_theme_onSecondaryContainer">#51577F</color>
+    <color name="md_theme_tertiary">#6E2073</color>
+    <color name="md_theme_onTertiary">#FFFFFF</color>
+    <color name="md_theme_tertiaryContainer">#893A8D</color>
+    <color name="md_theme_onTertiaryContainer">#FFBDFB</color>
+    <color name="md_theme_error">#BA1A1A</color>
+    <color name="md_theme_onError">#FFFFFF</color>
+    <color name="md_theme_errorContainer">#FFDAD6</color>
+    <color name="md_theme_onErrorContainer">#93000A</color>
+    <color name="md_theme_background">#FBF8FF</color>
+    <color name="md_theme_onBackground">#1A1B22</color>
+    <color name="md_theme_surface">#FBF8FF</color>
+    <color name="md_theme_onSurface">#1A1B22</color>
+    <color name="md_theme_surfaceVariant">#E2E1F1</color>
+    <color name="md_theme_onSurfaceVariant">#454652</color>
+    <color name="md_theme_outline">#757684</color>
+    <color name="md_theme_outlineVariant">#C5C5D4</color>
+    <color name="md_theme_scrim">#000000</color>
+    <color name="md_theme_inverseSurface">#2F3037</color>
+    <color name="md_theme_inverseOnSurface">#F2EFF9</color>
+    <color name="md_theme_inversePrimary">#BAC3FF</color>
+    <color name="md_theme_primaryFixed">#DEE0FF</color>
+    <color name="md_theme_onPrimaryFixed">#00105C</color>
+    <color name="md_theme_primaryFixedDim">#BAC3FF</color>
+    <color name="md_theme_onPrimaryFixedVariant">#293CA0</color>
+    <color name="md_theme_secondaryFixed">#DEE0FF</color>
+    <color name="md_theme_onSecondaryFixed">#12183D</color>
+    <color name="md_theme_secondaryFixedDim">#BEC4F2</color>
+    <color name="md_theme_onSecondaryFixedVariant">#3E446B</color>
+    <color name="md_theme_tertiaryFixed">#FFD6FA</color>
+    <color name="md_theme_onTertiaryFixed">#37003C</color>
+    <color name="md_theme_tertiaryFixedDim">#FFA9FD</color>
+    <color name="md_theme_onTertiaryFixedVariant">#722578</color>
+    <color name="md_theme_surfaceDim">#DBD9E2</color>
+    <color name="md_theme_surfaceBright">#FBF8FF</color>
+    <color name="md_theme_surfaceContainerLowest">#FFFFFF</color>
+    <color name="md_theme_surfaceContainerLow">#F4F2FC</color>
+    <color name="md_theme_surfaceContainer">#EFEDF6</color>
+    <color name="md_theme_surfaceContainerHigh">#E9E7F0</color>
+    <color name="md_theme_surfaceContainerHighest">#E3E1EA</color>
 </resources>

--- a/Source/GUI/Android/app/src/main/res/values/styles.xml
+++ b/Source/GUI/Android/app/src/main/res/values/styles.xml
@@ -8,10 +8,56 @@
 
 <resources>
     <!-- Base application theme. -->
-    <style name="AppTheme" parent="Theme.AppCompat.DayNight.DarkActionBar">
-        <item name="colorPrimary">@color/colorPrimary</item>
-        <item name="colorPrimaryDark">@color/colorPrimaryDark</item>
-        <item name="colorAccent">@color/colorAccent</item>
+    <style name="BaseTheme" parent="Theme.Material3.DayNight">
+        <item name="colorPrimary">@color/md_theme_primary</item>
+        <item name="colorOnPrimary">@color/md_theme_onPrimary</item>
+        <item name="colorPrimaryContainer">@color/md_theme_primaryContainer</item>
+        <item name="colorOnPrimaryContainer">@color/md_theme_onPrimaryContainer</item>
+        <item name="colorSecondary">@color/md_theme_secondary</item>
+        <item name="colorOnSecondary">@color/md_theme_onSecondary</item>
+        <item name="colorSecondaryContainer">@color/md_theme_secondaryContainer</item>
+        <item name="colorOnSecondaryContainer">@color/md_theme_onSecondaryContainer</item>
+        <item name="colorTertiary">@color/md_theme_tertiary</item>
+        <item name="colorOnTertiary">@color/md_theme_onTertiary</item>
+        <item name="colorTertiaryContainer">@color/md_theme_tertiaryContainer</item>
+        <item name="colorOnTertiaryContainer">@color/md_theme_onTertiaryContainer</item>
+        <item name="colorError">@color/md_theme_error</item>
+        <item name="colorOnError">@color/md_theme_onError</item>
+        <item name="colorErrorContainer">@color/md_theme_errorContainer</item>
+        <item name="colorOnErrorContainer">@color/md_theme_onErrorContainer</item>
+        <item name="android:colorBackground">@color/md_theme_background</item>
+        <item name="colorOnBackground">@color/md_theme_onBackground</item>
+        <item name="colorSurface">@color/md_theme_surface</item>
+        <item name="colorOnSurface">@color/md_theme_onSurface</item>
+        <item name="colorSurfaceVariant">@color/md_theme_surfaceVariant</item>
+        <item name="colorOnSurfaceVariant">@color/md_theme_onSurfaceVariant</item>
+        <item name="colorOutline">@color/md_theme_outline</item>
+        <item name="colorOutlineVariant">@color/md_theme_outlineVariant</item>
+        <item name="colorSurfaceInverse">@color/md_theme_inverseSurface</item>
+        <item name="colorOnSurfaceInverse">@color/md_theme_inverseOnSurface</item>
+        <item name="colorPrimaryInverse">@color/md_theme_inversePrimary</item>
+        <item name="colorPrimaryFixed">@color/md_theme_primaryFixed</item>
+        <item name="colorOnPrimaryFixed">@color/md_theme_onPrimaryFixed</item>
+        <item name="colorPrimaryFixedDim">@color/md_theme_primaryFixedDim</item>
+        <item name="colorOnPrimaryFixedVariant">@color/md_theme_onPrimaryFixedVariant</item>
+        <item name="colorSecondaryFixed">@color/md_theme_secondaryFixed</item>
+        <item name="colorOnSecondaryFixed">@color/md_theme_onSecondaryFixed</item>
+        <item name="colorSecondaryFixedDim">@color/md_theme_secondaryFixedDim</item>
+        <item name="colorOnSecondaryFixedVariant">@color/md_theme_onSecondaryFixedVariant</item>
+        <item name="colorTertiaryFixed">@color/md_theme_tertiaryFixed</item>
+        <item name="colorOnTertiaryFixed">@color/md_theme_onTertiaryFixed</item>
+        <item name="colorTertiaryFixedDim">@color/md_theme_tertiaryFixedDim</item>
+        <item name="colorOnTertiaryFixedVariant">@color/md_theme_onTertiaryFixedVariant</item>
+        <item name="colorSurfaceDim">@color/md_theme_surfaceDim</item>
+        <item name="colorSurfaceBright">@color/md_theme_surfaceBright</item>
+        <item name="colorSurfaceContainerLowest">@color/md_theme_surfaceContainerLowest</item>
+        <item name="colorSurfaceContainerLow">@color/md_theme_surfaceContainerLow</item>
+        <item name="colorSurfaceContainer">@color/md_theme_surfaceContainer</item>
+        <item name="colorSurfaceContainerHigh">@color/md_theme_surfaceContainerHigh</item>
+        <item name="colorSurfaceContainerHighest">@color/md_theme_surfaceContainerHighest</item>
+    </style>
+
+    <style name="AppTheme" parent="BaseTheme">
     </style>
 
     <style name="AppTheme.NoActionBar" parent="AppTheme">
@@ -19,11 +65,8 @@
         <item name="windowNoTitle">true</item>
     </style>
 
-    <style name="AppTheme.Dialog" parent="Theme.AppCompat.DayNight.Dialog">
+    <style name="AppTheme.Dialog" parent="Theme.Material3.DayNight.Dialog">
         <item name="windowNoTitle">true</item>
     </style>
 
-   <style name="AppTheme.AppBarOverlay" parent="ThemeOverlay.AppCompat.Dark.ActionBar" />
-
-    <style name="AppTheme.PopupOverlay" parent="ThemeOverlay.AppCompat.Light" />
 </resources>

--- a/Source/GUI/Android/build.gradle
+++ b/Source/GUI/Android/build.gradle
@@ -8,8 +8,8 @@ buildscript {
     }
     dependencies {
         classpath 'org.codehaus.groovy:groovy-all:3.0.25'
-        classpath 'com.android.tools.build:gradle:8.11.1'
-        classpath 'com.android.tools.build:gradle-settings-api:8.11.1'
+        classpath 'com.android.tools.build:gradle:8.11.2'
+        classpath 'com.android.tools.build:gradle-settings-api:8.11.2'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
 
         // NOTE: Do not place your application dependencies here; they belong


### PR DESCRIPTION
Migrate to Material 3 design and enable dynamic theming along with fixing invisible white status bar icons. Also make 'About' page scroll-able when needed (for example landscape mode on small devices or split screen).
