### PR TITLE
build(cli): Adjust library name for MediaInfoLib dependency when using CMake

### DIFF
--- a/Project/CMake/CLI/CMakeLists.txt
+++ b/Project/CMake/CLI/CMakeLists.txt
@@ -28,7 +28,7 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR}/../../../Source)
 
 find_package(ZLIB REQUIRED)
 find_package(Threads REQUIRED)
-find_package(mediainfolib REQUIRED)
+find_package(MediaInfoLib REQUIRED)
 find_package(ZenLib REQUIRED)
 
 set_target_properties(mediainfo_cli PROPERTIES OUTPUT_NAME mediainfo)
@@ -45,3 +45,4 @@ target_link_libraries(mediainfo_cli
 )
 
 install(TARGETS mediainfo_cli DESTINATION bin)
+


### PR DESCRIPTION
…g CMake

CMake files for MediaInfoLib uses capitals but the CMake build script looks for library with lower-case only which causes it to fail finding it on case sensistive file systems