### PR TITLE
CMake: Include resource file for CLI

### DIFF
--- a/Project/CMake/CLI/CMakeLists.txt
+++ b/Project/CMake/CLI/CMakeLists.txt
@@ -13,6 +13,7 @@ set(CLI_SOURCES
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../Source/CLI/CommandLine_Parser.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../Source/CLI/Help.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/../../../Source/Common/Core.cpp
+    ${CMAKE_CURRENT_SOURCE_DIR}/../../MSVC2022/CLI/MediaInfo_CLI.rc
 )
 
 add_executable(mediainfo_cli ${CLI_SOURCES})


### PR DESCRIPTION
The CLI built with CMake was missing name/description/company/version/copyright information.
