### PR TITLE
Fix CI

### DIFF
--- a/.github/workflows/MediaInfo-Qt_Checks.yml
+++ b/.github/workflows/MediaInfo-Qt_Checks.yml
@@ -16,7 +16,7 @@ on:
       - 'Source/Resource/**'
 
 env:
-  QT_VER: 6.*
+  QT_VER: 6.10.*
   QT_SELECT: 6
 
 jobs:


### PR DESCRIPTION
Limit Qt version to 6.10.* because otherwise aqtinstall used by install Qt action selects version 6.11 which is not released yet (it will only feature freeze and branch from dev this week) and which it fails to install.
