### PR TITLE
iOS GUI: Explicitly release iCloud-downloaded files

### DIFF
--- a/Source/GUI/iOS/MediaInfo/AppDelegate.swift
+++ b/Source/GUI/iOS/MediaInfo/AppDelegate.swift
@@ -26,6 +26,8 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
         SKPaymentQueue.default().add(self)
         subscriptionManager.loadSubscription()
 
+        cleanupLegacyCache()
+
         return true
     }
 
@@ -44,6 +46,47 @@ class AppDelegate: UIResponder, UIApplicationDelegate, UISplitViewControllerDele
     func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate.
         self.saveContext()
+    }
+
+    /// One-time cleanup of locally cached iCloud files and temporary files
+    /// left behind by previous versions.
+    private func cleanupLegacyCache() {
+        let cleanupKey = "hasCleanedLegacyIcloudCache"
+
+        if UserDefaults.standard.bool(forKey: cleanupKey) {
+            return
+        }
+
+        DispatchQueue.global(qos: .utility).async {
+            let fileManager = FileManager.default
+
+            // Clean up any locally cached iCloud files from the app's ubiquity container
+            if let containerURL = fileManager.url(forUbiquityContainerIdentifier: nil) {
+                let documentsURL = containerURL.appendingPathComponent("Documents")
+                if let enumerator = fileManager.enumerator(at: documentsURL,
+                                                           includingPropertiesForKeys: [.isUbiquitousItemKey],
+                                                           options: [.skipsHiddenFiles]) {
+                    for case let fileURL as URL in enumerator {
+                        if let resourceValues = try? fileURL.resourceValues(forKeys: [.isUbiquitousItemKey]) {
+                            if resourceValues.isUbiquitousItem == true {
+                                try? fileManager.evictUbiquitousItem(at: fileURL)
+                            }
+                        }
+                    }
+                }
+            }
+
+            // Clean up any temporary files from old versions
+            let tmpDir = NSTemporaryDirectory()
+            if let files = try? fileManager.contentsOfDirectory(atPath: tmpDir) {
+                for file in files {
+                    let filePath = (tmpDir as NSString).appendingPathComponent(file)
+                    try? fileManager.removeItem(atPath: filePath)
+                }
+            }
+
+            UserDefaults.standard.set(true, forKey: cleanupKey)
+        }
     }
 
     // MARK: - Split view

--- a/Source/GUI/iOS/MediaInfo/ReportViewController.swift
+++ b/Source/GUI/iOS/MediaInfo/ReportViewController.swift
@@ -211,4 +211,24 @@ class ReportViewController: UIViewController, UIDocumentPickerDelegate {
             }
         }
     }
+
+    func documentPicker(_ controller: UIDocumentPickerViewController, didPickDocuments urls: [URL]) {
+        cleanupTemporaryFiles()
+    }
+
+    func documentPickerWasCancelled(_ controller: UIDocumentPickerViewController) {
+        cleanupTemporaryFiles()
+    }
+
+    // Clean up temporary files created for exporting reports.
+    private func cleanupTemporaryFiles() {
+        let fileManager = FileManager.default
+        let tmpDir = NSTemporaryDirectory()
+        if let files = try? fileManager.contentsOfDirectory(atPath: tmpDir) {
+            for file in files {
+                let filePath = (tmpDir as NSString).appendingPathComponent(file)
+                try? fileManager.removeItem(atPath: filePath)
+            }
+        }
+    }
 }

--- a/Source/GUI/iOS/MediaInfo/ReportsListViewController.swift
+++ b/Source/GUI/iOS/MediaInfo/ReportsListViewController.swift
@@ -343,9 +343,14 @@ class ReportsListViewController: UITableViewController, NSFetchedResultsControll
         return nil
     }
 
-    func extractFileUrls(urls: [URL]) -> [URL] {
+    func evictIcloudFile(url: URL) {
+        try? FileManager.default.evictUbiquitousItem(at: url) // Eviction is best-effort; file may not be ubiquitous
+    }
+
+    func extractFileUrls(urls: [URL]) -> (fileUrls: [URL], icloudUrls: [URL]) {
         let fileManager: FileManager = FileManager.default
         var toReturn: [URL] = [URL]()
+        var icloudDownloaded: [URL] = [URL]()
 
         for url in urls {
             if isDirectoryUrl(url: url) {
@@ -357,6 +362,7 @@ class ReportsListViewController: UITableViewController, NSFetchedResultsControll
                         if (lastPathComponent.hasPrefix(".") && lastPathComponent.hasSuffix(".icloud")) {
                             if let file: URL = retreiveFileFromIcloud(url: cur) {
                                 toReturn.append(file)
+                                icloudDownloaded.append(file)
                             }
                         } else {
                             toReturn.append(cur)
@@ -368,6 +374,7 @@ class ReportsListViewController: UITableViewController, NSFetchedResultsControll
                 if (lastPathComponent.hasPrefix(".") && lastPathComponent.hasSuffix(".icloud")) {
                     if let file: URL = retreiveFileFromIcloud(url: url) {
                         toReturn.append(file)
+                        icloudDownloaded.append(file)
                     }
                 } else {
                     toReturn.append(url)
@@ -375,7 +382,7 @@ class ReportsListViewController: UITableViewController, NSFetchedResultsControll
             }
         }
 
-        return toReturn
+        return (toReturn, icloudDownloaded)
     }
 
     // MARK: - PHPickerViewControllerDelegate
@@ -512,7 +519,10 @@ class ReportsListViewController: UITableViewController, NSFetchedResultsControll
 
         DispatchQueue.main.async { [weak self] in
             if let main = self {
-                let fileUrls: [URL] = main.extractFileUrls(urls: urls)
+                let result = main.extractFileUrls(urls: urls)
+                let fileUrls = result.fileUrls
+                let icloudUrls = result.icloudUrls
+
                 for url in fileUrls {
                      do {
                         let report = try main.core.createReport(url: url, name: url.lastPathComponent)
@@ -538,6 +548,16 @@ class ReportsListViewController: UITableViewController, NSFetchedResultsControll
 
                         main.view.makeToast("ERROR: \(nserror), \(nserror.userInfo) when trying to save report", duration: 5.0, position: .top)
                     }
+                }
+
+                // Evict iCloud files to free local disk space
+                for icloudUrl in icloudUrls {
+                    main.evictIcloudFile(url: icloudUrl)
+                }
+
+                // Clean up temporary files created by .import document picker
+                for url in urls {
+                    try? FileManager.default.removeItem(at: url)
                 }
 
                 main.view.hideToastActivity()


### PR DESCRIPTION
Try to fix the reported bug about MediaInfo filling up device space.