### PR TITLE
CI: Update actions

### DIFF
--- a/.github/actions/setup-msvc/action.yml
+++ b/.github/actions/setup-msvc/action.yml
@@ -1,0 +1,50 @@
+# Adapted from code generated with Google Gemini 3
+
+name: 'Setup MSVC Environment'
+description: 'Mirror the full vcvarsall.bat environment'
+inputs:
+  arch:
+    description: 'Target architecture (what is passed to vcvarsall, default follows runner OS)'
+    required: false
+    default: ''
+
+runs:
+  using: "composite"
+  steps:
+    - name: Configure MSVC Environment
+      shell: pwsh
+      run: |
+        # 1. Determine Architecture
+        $targetArch = "${{ inputs.arch }}".ToLower()
+        if (-not $targetArch) {
+            $targetArch = "$env:RUNNER_ARCH".ToLower()
+        }
+
+        # 2. Find vcvarsall.bat
+        $installPath = & "${env:ProgramFiles(x86)}\Microsoft Visual Studio\Installer\vswhere.exe" -latest -products * -requires Microsoft.VisualStudio.Component.VC.Tools.x86.x64 -property installationPath
+        $vcvarsPath = Join-Path $installPath "VC\Auxiliary\Build\vcvarsall.bat"
+
+        if (-not (Test-Path $vcvarsPath)) {
+            Write-Error "vcvarsall.bat not found at $vcvarsPath"
+            exit 1
+        }
+
+        # 3. Run vcvarsall and capture environment variables
+        # Use an array for arguments. PowerShell will handle the quoting correctly.
+        $cmdArgs = @("/c", "(`"$vcvarsPath`" $targetArch) & echo. & set")
+        $envData = & cmd.exe @cmdArgs 2>&1
+        if ([string]::IsNullOrWhiteSpace($envData) -or $envData -match "is not recognized|Error in script usage") {
+            Write-Error "vcvarsall.bat failed to execute."
+            $envData
+            exit 1
+        }
+
+        # 4. Apply Environment Variables
+        foreach ($line in $envData) {
+            if ($line -match "^[^=]+=.+$") {
+                $line >> $Env:GITHUB_ENV
+            }
+        }
+
+        Write-Host "`nSuccessfully configured MSVC ($targetArch) environment.`n"
+        Write-Host $envData -Separator "`n"

--- a/.github/workflows/MediaInfo-Qt_Checks.yml
+++ b/.github/workflows/MediaInfo-Qt_Checks.yml
@@ -61,7 +61,7 @@ jobs:
           version: ${{ env.QT_VER }}
           cache: true
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
         with:
           msbuild-architecture: ${{ runner.arch == 'ARM64' && 'arm64' || 'x64' }}
       - name: Build dependencies

--- a/.github/workflows/MediaInfo_Checks.yml
+++ b/.github/workflows/MediaInfo_Checks.yml
@@ -117,7 +117,7 @@ jobs:
         with:
           path: MediaInfo
       - name: Add msbuild to PATH
-        uses: microsoft/setup-msbuild@v2
+        uses: microsoft/setup-msbuild@v3
         with:
           msbuild-architecture: ${{ runner.arch == 'ARM64' && 'arm64' || 'x64' }}
       - name: Build
@@ -188,11 +188,9 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: MediaInfo
-      - name: Setup MSVC Developer Command Prompt
+      - name: Setup MSVC Environment
         if: ${{ runner.os == 'Windows' }}
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: ${{ runner.arch == 'ARM64' && 'arm64' || 'x64' }}
+        uses: ./MediaInfo/.github/actions/setup-msvc
       - name: Build dependencies
         if: ${{ matrix.type == 'Windows (DLL) (x64)' }}
         run: |


### PR DESCRIPTION
Update microsoft/setup-msbuild to v3 to support Node 24.

Migrate ilammy/msvc-dev-cmd to in-house action as it uses deprecated Node 20 and is not updated in over 2 years. Since it is something that is not too difficult to be done, use an in-house action to reduce third-party dependence and lower risk of supply chain attacks. It is implemented without any dependencies (such as Node) and is made to support various MSVC version and editions so it should not need to be updated unless something breaks due to change in VS or a bug is found.
