### PR TITLE
Add support for context menu entry on KDE 6

### DIFF
--- a/Project/GNU/GUI/Makefile.am
+++ b/Project/GNU/GUI/Makefile.am
@@ -45,6 +45,9 @@ install-data-hook:
 	install -dm 755 $(DESTDIR)$(datadir)/kservices5/ServiceMenus && \
 	install -m 644 mediainfo-gui.kde4.desktop \
 	               $(DESTDIR)$(datadir)/kservices5/ServiceMenus/mediainfo-gui.desktop && \
+	install -dm 755 $(DESTDIR)$(datadir)/kio/servicemenus && \
+	install -m 644 mediainfo-gui.kde6.desktop \
+	               $(DESTDIR)$(datadir)/kio/servicemenus/mediainfo-gui.desktop && \
 	install -dm 755 $(DESTDIR)$(datadir)/icons/hicolor/256x256/apps && \
 	install -m 644 ../../../Source/Resource/Image/MediaInfo.png \
 	               $(DESTDIR)$(datadir)/icons/hicolor/256x256/apps/mediainfo.png && \
@@ -59,6 +62,7 @@ uninstall-local:
 	( cd '$(DESTDIR)$(datadir)/apps/konqueror/servicemenus' && rm -f mediainfo-gui.desktop ) && \
 	( cd '$(DESTDIR)$(datadir)/kde4/services/ServiceMenus' && rm -f mediainfo-gui.desktop ) && \
 	( cd '$(DESTDIR)$(datadir)/kservices5/ServiceMenus' && rm -f mediainfo-gui.desktop ) && \
+	( cd '$(DESTDIR)$(datadir)/kio/servicemenus' && rm -f mediainfo-gui.desktop ) && \
 	( cd '$(DESTDIR)$(datadir)/icons/hicolor/256x256/apps' && rm -f mediainfo.png ) && \
 	( cd '$(DESTDIR)$(datadir)/icons/hicolor/scalable/apps' && rm -f mediainfo.svg ) && \
 	( cd '$(DESTDIR)$(datadir)/pixmaps' && rm -f mediainfo.xpm )

--- a/Project/GNU/GUI/mediainfo-gui.kde6.desktop
+++ b/Project/GNU/GUI/mediainfo-gui.kde6.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Type=Service
+MimeType=audio/*;video/*;image/*;application/x-flash-video
+Actions=mediainfo-gui
+X-KDE-Priority=TopLevel
+Keywords=media info;metadata;tag;video;audio;subtitles;chapters;codec;mkv;mpeg;mp3;h264;avc;h265;hevc;avi;
+
+[Desktop Action mediainfo-gui]
+Name=MediaInfo
+GenericName=Media Analyzer
+Exec=mediainfo-gui %u
+Icon=mediainfo

--- a/Project/GNU/mediainfo.spec
+++ b/Project/GNU/mediainfo.spec
@@ -289,6 +289,9 @@ install -m 644 Project/GNU/GUI/mediainfo-gui.metainfo.xml %{buildroot}%{_datadir
 %dir %{_datadir}/kservices5\
 %dir %{_datadir}/kservices5/ServiceMenus\
 %{_datadir}/kservices5/ServiceMenus/*.desktop\
+%dir %{_datadir}/kio\
+%dir %{_datadir}/kio/servicemenus\
+%{_datadir}/kio/servicemenus/*.desktop\
 %if 0%{?fedora_version} && 0%{?fedora_version} >= 26\
 %dir %{_datadir}/metainfo\
 %{_datadir}/metainfo/*.xml\

--- a/Project/OBS/deb10.debian/mediainfo-gui.install
+++ b/Project/OBS/deb10.debian/mediainfo-gui.install
@@ -9,3 +9,4 @@
 /usr/share/apps/konqueror/servicemenus/mediainfo-gui.desktop
 /usr/share/kde4/services/ServiceMenus/mediainfo-gui.desktop
 /usr/share/kservices5/ServiceMenus/mediainfo-gui.desktop
+/usr/share/kio/servicemenus/mediainfo-gui.desktop

--- a/Project/OBS/deb12.debian/mediainfo-gui.install
+++ b/Project/OBS/deb12.debian/mediainfo-gui.install
@@ -9,3 +9,4 @@
 /usr/share/apps/konqueror/servicemenus/mediainfo-gui.desktop
 /usr/share/kde4/services/ServiceMenus/mediainfo-gui.desktop
 /usr/share/kservices5/ServiceMenus/mediainfo-gui.desktop
+/usr/share/kio/servicemenus/mediainfo-gui.desktop

--- a/Project/OBS/deb7.debian/mediainfo-gui.install
+++ b/Project/OBS/deb7.debian/mediainfo-gui.install
@@ -9,3 +9,4 @@
 /usr/share/apps/konqueror/servicemenus/mediainfo-gui.desktop
 /usr/share/kde4/services/ServiceMenus/mediainfo-gui.desktop
 /usr/share/kservices5/ServiceMenus/mediainfo-gui.desktop
+/usr/share/kio/servicemenus/mediainfo-gui.desktop

--- a/Project/OBS/deb9.debian/mediainfo-gui.install
+++ b/Project/OBS/deb9.debian/mediainfo-gui.install
@@ -9,3 +9,4 @@
 /usr/share/apps/konqueror/servicemenus/mediainfo-gui.desktop
 /usr/share/kde4/services/ServiceMenus/mediainfo-gui.desktop
 /usr/share/kservices5/ServiceMenus/mediainfo-gui.desktop
+/usr/share/kio/servicemenus/mediainfo-gui.desktop

--- a/debian/mediainfo-gui.install
+++ b/debian/mediainfo-gui.install
@@ -9,3 +9,4 @@
 /usr/share/apps/konqueror/servicemenus/mediainfo-gui.desktop
 /usr/share/kde4/services/ServiceMenus/mediainfo-gui.desktop
 /usr/share/kservices5/ServiceMenus/mediainfo-gui.desktop
+/usr/share/kio/servicemenus/mediainfo-gui.desktop


### PR DESCRIPTION
KDE 6 uses `/usr/share/kio/servicemenus` instead of `/usr/share/kservices5/ServiceMenus`. The file format is also a bit different. KDE 6 uses the standard `MimeType` field now instead of `ServiceTypes`.

Tested on Fedora 44 with KDE Plasma 6.6.4:

<img width="688" height="748" alt="image" src="https://github.com/user-attachments/assets/a49a46d5-b129-4874-8e70-209b0f077abc" />
