### PR TITLE
Android: Only export JNI_OnLoad in libmediainfo.so

### DIFF
--- a/.github/workflows/MediaInfo-Android_Checks.yml
+++ b/.github/workflows/MediaInfo-Android_Checks.yml
@@ -38,9 +38,13 @@ jobs:
         uses: actions/checkout@v6
         with:
           path: MediaInfo
+      - name: Setup Java
+        uses: actions/setup-java@v5
+        with:
+          distribution: 'jetbrains'
+          java-version: ${{ env.JAVA_VER }}
       - name: Build APKs
         run: |
-          export JAVA_HOME="$JAVA_HOME_${{ env.JAVA_VER }}_X64"
           pushd ${{ github.workspace }}/MediaInfo/Source/GUI/Android
           chmod +x gradlew
           ./gradlew assembleRelease --warning-mode fail

--- a/Source/GUI/Android/app/CMakeLists.txt
+++ b/Source/GUI/Android/app/CMakeLists.txt
@@ -12,6 +12,20 @@ set(BUILD_ZENLIB ON CACHE BOOL "Build bundled ZenLib" FORCE)
 
 add_subdirectory(../../../../../MediaInfoLib/Project/CMake ${CMAKE_CURRENT_BINARY_DIR}/MediaInfoLib)
 
+target_link_options(mediainfo
+        PRIVATE
+        -Wl,--version-script,${CMAKE_CURRENT_SOURCE_DIR}/libmediainfo.map.txt
+        # This causes the linker to emit an error when a version script names a
+        # symbol that is not found, rather than silently ignoring that line.
+        -Wl,--no-undefined-version
+)
+
+# Without this, changes to the version script will not cause the library to relink.
+set_target_properties(mediainfo
+        PROPERTIES
+        LINK_DEPENDS ${CMAKE_CURRENT_SOURCE_DIR}/libmediainfo.map.txt
+)
+
 # disable warning in aes_via_ace.h for x86 arch
 if(NOT "${CMAKE_VERSION}" VERSION_LESS "3.18")
     set_property(

--- a/Source/GUI/Android/app/libmediainfo.map.txt
+++ b/Source/GUI/Android/app/libmediainfo.map.txt
@@ -1,0 +1,14 @@
+# The name used here also doesn't matter. This is the name of the "version"
+# which matters when the version script is actually used to create multiple
+# versions of the same symbol, but that's not what we're doing.
+LIBMEDIAINFO {
+  global:
+    # Every symbol named in this section will have "default" (that is, public)
+    # visibility. See below for how to refer to C++ symbols without mangling.
+    JNI_OnLoad;
+  local:
+    # Every symbol in this section will have "local" (that is, hidden)
+    # visibility. The wildcard * is used to indicate that all symbols not listed
+    # in the global section should be hidden.
+    *;
+};


### PR DESCRIPTION
By default, NDK linker follows ELF default of making every symbol visible. By only exporting the single symbol we actually need (JNI_OnLoad), the size of the .so file and APK can be further reduced due to removal of symbol names and unreachable code. It also improves library load performance as there are less symbols. Also prevents conflicts with other .so files that may be added to app in future due to symbols from statically linked libc++ that may be visible otherwise.
