### PR TITLE
Android GUI: Improve layout and accessibility

### DIFF
--- a/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/ReportListActivity.kt
+++ b/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/ReportListActivity.kt
@@ -13,6 +13,7 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
+import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.app.ActivityCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
@@ -42,6 +43,7 @@ import android.content.res.Configuration
 import android.content.res.Resources
 import android.provider.Settings
 import android.view.*
+import androidx.core.view.updateLayoutParams
 
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
@@ -564,6 +566,14 @@ class ReportListActivity : AppCompatActivity(), ReportActivityListener {
             )
             insets
         }
+        ViewCompat.setOnApplyWindowInsetsListener(activityReportListBinding.addButton) { v: View, insets: WindowInsetsCompat ->
+            val bars = insets.getInsets(WindowInsetsCompat.Type.systemBars()
+                    or WindowInsetsCompat.Type.displayCutout())
+            v.updateLayoutParams<ViewGroup.MarginLayoutParams> {
+                bottomMargin = bars.bottom + resources.getDimensionPixelSize(R.dimen.button_margin)
+            }
+            insets
+        }
 
         setContentView(activityReportListBinding.root)
 
@@ -673,6 +683,15 @@ class ReportListActivity : AppCompatActivity(), ReportActivityListener {
                     .detach(fragment)
                     .commit()
             }
+        }
+
+        val addButtonParams = activityReportListBinding.addButton.layoutParams as CoordinatorLayout.LayoutParams
+        if (twoPane) {
+            addButtonParams.anchorId = R.id.report_list_scrollview
+            addButtonParams.gravity = Gravity.BOTTOM or Gravity.START
+        } else {
+            addButtonParams.anchorId = R.id.report_list_layout
+            addButtonParams.gravity = Gravity.BOTTOM or Gravity.END
         }
 
         setupRecyclerView(activityReportListBinding.reportListLayout.reportList)

--- a/Source/GUI/Android/app/src/main/res/drawable/ic_report_close.xml
+++ b/Source/GUI/Android/app/src/main/res/drawable/ic_report_close.xml
@@ -3,7 +3,7 @@
         android:height="24dp"
         android:viewportWidth="24.0"
         android:viewportHeight="24.0"
-        android:tint="#FFCCCCCC">
+        android:tint="@color/md_theme_outline">
     <path
         android:fillColor="#FFFFFFFF"
         android:pathData="M19,6.41L17.59,5 12,10.59 6.41,5 5,6.41 10.59,12 5,17.59 6.41,19 12,13.41 17.59,19 19,17.59 13.41,12z"/>

--- a/Source/GUI/Android/app/src/main/res/layout-w900dp/report_list.xml
+++ b/Source/GUI/Android/app/src/main/res/layout-w900dp/report_list.xml
@@ -47,7 +47,7 @@
                 android:id="@+id/clear_btn"
                 android:layout_width="wrap_content"
                 android:layout_height="wrap_content"
-                android:textColor="#FFCCCCCC"
+                android:textColor="@color/md_theme_onSurfaceVariant"
                 android:text="@string/clear_text"
                 android:layout_gravity="center"
                 style="@style/Widget.AppCompat.Button.Borderless" />

--- a/Source/GUI/Android/app/src/main/res/layout-w900dp/report_list.xml
+++ b/Source/GUI/Android/app/src/main/res/layout-w900dp/report_list.xml
@@ -23,6 +23,7 @@
     <!-- This layout is a two-pane layout for the master/detail flow. -->
 
     <androidx.core.widget.NestedScrollView
+        android:id="@+id/report_list_scrollview"
         android:layout_width="@dimen/item_width"
         android:layout_height="match_parent"
         android:layout_marginLeft="2dp"
@@ -50,6 +51,9 @@
                 android:text="@string/clear_text"
                 android:layout_gravity="center"
                 style="@style/Widget.AppCompat.Button.Borderless" />
+            <View
+                android:layout_width="match_parent"
+                android:layout_height="@dimen/button_bottom_clearance" />
         </LinearLayout>
     </androidx.core.widget.NestedScrollView>
     <FrameLayout

--- a/Source/GUI/Android/app/src/main/res/layout/activity_report_list.xml
+++ b/Source/GUI/Android/app/src/main/res/layout/activity_report_list.xml
@@ -33,14 +33,16 @@
         android:layout_height="match_parent"
         app:layout_behavior="@string/appbar_scrolling_view_behavior">
         <include android:id="@+id/report_list_layout" layout="@layout/report_list" />
-        <com.google.android.material.floatingactionbutton.FloatingActionButton
-            android:id="@+id/add_button"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:layout_gravity="bottom|end"
-            android:layout_margin="@dimen/button_margin"
-            android:contentDescription="@string/open_title"
-            app:srcCompat="@drawable/ic_action_add" />
     </FrameLayout>
+
+    <com.google.android.material.floatingactionbutton.FloatingActionButton
+        android:id="@+id/add_button"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_gravity="bottom|end"
+        android:layout_margin="@dimen/button_margin"
+        android:contentDescription="@string/open_title"
+        app:layout_anchorGravity="bottom|end"
+        app:srcCompat="@drawable/ic_action_add" />
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Source/GUI/Android/app/src/main/res/layout/report_list.xml
+++ b/Source/GUI/Android/app/src/main/res/layout/report_list.xml
@@ -34,5 +34,8 @@
             android:text="@string/clear_text"
             android:layout_gravity="center"
             style="@style/Widget.AppCompat.Button.Borderless" />
+        <View
+            android:layout_width="match_parent"
+            android:layout_height="@dimen/button_bottom_clearance" />
     </LinearLayout>
 </androidx.core.widget.NestedScrollView>

--- a/Source/GUI/Android/app/src/main/res/layout/report_list.xml
+++ b/Source/GUI/Android/app/src/main/res/layout/report_list.xml
@@ -30,7 +30,7 @@
             android:id="@+id/clear_btn"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:textColor="#FFCCCCCC"
+            android:textColor="@color/md_theme_onSurfaceVariant"
             android:text="@string/clear_text"
             android:layout_gravity="center"
             style="@style/Widget.AppCompat.Button.Borderless" />

--- a/Source/GUI/Android/app/src/main/res/layout/report_list_content.xml
+++ b/Source/GUI/Android/app/src/main/res/layout/report_list_content.xml
@@ -24,13 +24,11 @@
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_toStartOf="@+id/delete_button"
-        android:layout_toLeftOf="@+id/delete_button"
         android:layout_margin="@dimen/text_margin"
         android:maxLines="1"
         android:ellipsize="end"
         android:textAppearance="?attr/textAppearanceListItem"
-        android:layout_alignParentStart="true"
-        android:layout_alignParentLeft="true" />
+        android:layout_alignParentStart="true" />
 
     <ImageButton
         android:id="@+id/delete_button"
@@ -39,7 +37,6 @@
         android:background="@android:color/transparent"
         android:padding="12dp"
         android:layout_alignParentEnd="true"
-        android:layout_alignParentRight="true"
         android:layout_centerVertical="true"
         android:contentDescription="@string/delete_desc"
         app:srcCompat="@drawable/ic_report_close" />

--- a/Source/GUI/Android/app/src/main/res/layout/report_list_content.xml
+++ b/Source/GUI/Android/app/src/main/res/layout/report_list_content.xml
@@ -20,6 +20,7 @@
 
     <TextView
         android:id="@+id/name_text"
+        android:layout_centerVertical="true"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_toStartOf="@+id/delete_button"
@@ -36,6 +37,7 @@
         android:layout_height="wrap_content"
         android:layout_width="wrap_content"
         android:background="@android:color/transparent"
+        android:padding="12dp"
         android:layout_alignParentEnd="true"
         android:layout_alignParentRight="true"
         android:layout_centerVertical="true"

--- a/Source/GUI/Android/app/src/main/res/values/dimens.xml
+++ b/Source/GUI/Android/app/src/main/res/values/dimens.xml
@@ -7,6 +7,8 @@
 -->
 
 <resources>
+    <!-- Standard FAB (56dp) + button_margin (16dp) + Extra (8dp) -->
+    <dimen name="button_bottom_clearance">80dp</dimen>
     <dimen name="button_margin">16dp</dimen>
     <dimen name="text_margin">8dp</dimen>
     <dimen name="item_width">300dp</dimen>


### PR DESCRIPTION
- Make report list able to scroll content above the floating action button (FAB) so that content is not blocked by it.
- Make FAB stay within report list in two pane mode since it belongs there and so it doesn't block the report.
- Improve colour contrast of report list buttons for accessibility and to remove IDE warnings.
- Increase touch size of report list items for accessibility and to remove IDE errors. [48dp is minimum for touch target size](https://support.google.com/accessibility/android/answer/7101858?hl=en).
- Remove redundant XML attributes that IDE says is redundant for MediaInfo's current targetSDK.

<img height="480" alt="Screenshot_20260505_180234" src="https://github.com/user-attachments/assets/458a5639-24f2-4536-bff3-72c2b97a634e" />

<img width="480" alt="Screenshot_20260505_180347" src="https://github.com/user-attachments/assets/0b26beae-2a39-4c27-a85f-195e99ba992f" />
