### PR TITLE
Android GUI: Report list improvements

### DIFF
--- a/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/ReportListActivity.kt
+++ b/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/ReportListActivity.kt
@@ -17,6 +17,7 @@ import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.app.ActivityCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
+import androidx.core.view.updateLayoutParams
 import androidx.core.view.updatePadding
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowCompat
@@ -43,7 +44,6 @@ import android.content.res.Configuration
 import android.content.res.Resources
 import android.provider.Settings
 import android.view.*
-import androidx.core.view.updateLayoutParams
 
 import io.reactivex.disposables.CompositeDisposable
 import io.reactivex.schedulers.Schedulers
@@ -54,6 +54,7 @@ import java.io.BufferedReader
 import java.util.*
 
 import  net.mediaarea.mediainfo.databinding.ActivityReportListBinding
+import  net.mediaarea.mediainfo.databinding.ClearButtonBinding
 import  net.mediaarea.mediainfo.databinding.ReportListContentBinding
 import  net.mediaarea.mediainfo.databinding.HelloLayoutBinding
 
@@ -648,25 +649,6 @@ class ReportListActivity : AppCompatActivity(), ReportActivityListener {
             }
             openFile.launch("*/*")
         }
-        activityReportListBinding.reportListLayout.clearBtn.setOnClickListener {
-            disposable.add(reportModel.deleteAllReports()
-                .subscribeOn(Schedulers.io())
-                .observeOn(AndroidSchedulers.mainThread())
-                .subscribe {
-                    intent.putExtra(Core.ARG_REPORT_ID, -1)
-                    if (twoPane) {
-                        val fragment = supportFragmentManager.findFragmentById(R.id.report_detail_container)
-                        if (fragment != null) {
-                            supportFragmentManager
-                                .beginTransaction()
-                                .detach(fragment)
-                                .commit()
-
-                                title = getString(R.string.app_name)
-                        }
-                    }
-            })
-        }
 
         // The detail container view will be present only in the
         // large-screen layouts (res/values-w900dp).
@@ -687,7 +669,7 @@ class ReportListActivity : AppCompatActivity(), ReportActivityListener {
 
         val addButtonParams = activityReportListBinding.addButton.layoutParams as CoordinatorLayout.LayoutParams
         if (twoPane) {
-            addButtonParams.anchorId = R.id.report_list_scrollview
+            addButtonParams.anchorId = R.id.report_list
             addButtonParams.gravity = Gravity.BOTTOM or Gravity.START
         } else {
             addButtonParams.anchorId = R.id.report_list_layout
@@ -720,16 +702,12 @@ class ReportListActivity : AppCompatActivity(), ReportActivityListener {
                         if (!found)
                             View.inflate(this, R.layout.hello_layout, rootLayout)
 
-                        activityReportListBinding.reportListLayout.clearBtn.visibility = View.INVISIBLE
                     } else {
                         for (i: Int in rootLayout.childCount downTo 1) {
                             if (rootLayout.getChildAt(i - 1).id == R.id.hello_layout)
                                 rootLayout.removeViewAt(i - 1)
                         }
                         rootLayout.removeView(helloLayoutBinding.root)
-                        activityReportListBinding.reportListLayout.clearBtn.visibility = View.VISIBLE
-
-
                     }
                 })
 
@@ -748,33 +726,65 @@ class ReportListActivity : AppCompatActivity(), ReportActivityListener {
     @SuppressLint("NotifyDataSetChanged")
     private fun setupRecyclerView(recyclerView: RecyclerView) {
         recyclerView.adapter = ItemRecyclerViewAdapter()
-        recyclerView.isNestedScrollingEnabled = false
         recyclerView.adapter?.notifyDataSetChanged()
     }
 
-    inner class ItemRecyclerViewAdapter : RecyclerView.Adapter<ItemRecyclerViewAdapter.ViewHolder>() {
+    inner class ItemRecyclerViewAdapter : RecyclerView.Adapter<RecyclerView.ViewHolder>() {
         private val onClickListener: View.OnClickListener = View.OnClickListener {
             showReport((it.tag as Report).id)
         }
 
-        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): ViewHolder {
-            val binding = ReportListContentBinding.inflate(layoutInflater, parent, false)
-            return ViewHolder(binding)
+        override fun getItemViewType(position: Int): Int {
+            return if (position == reports.size) BUTTON_VIEW_TYPE else ITEM_VIEW_TYPE
         }
 
-        override fun onBindViewHolder(holder: ViewHolder, position: Int) {
-            val report: Report = reports[position]
-            holder.name.text = report.filename
-            holder.id = report.id
+        override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
+            if (viewType == ITEM_VIEW_TYPE) {
+                val binding = ReportListContentBinding.inflate(layoutInflater, parent, false)
+                return ViewHolder(binding)
+            } else {
+                val binding = ClearButtonBinding.inflate(layoutInflater, parent, false)
+                return ButtonViewHolder(binding)
+            }
+        }
 
-            with(holder.itemView) {
-                tag = report
-                setOnClickListener(onClickListener)
+        override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
+            when (holder) {
+                is ViewHolder -> {
+                    val report: Report = reports[position]
+                    holder.name.text = report.filename
+                    holder.id = report.id
+                    with(holder.itemView) {
+                        tag = report
+                        setOnClickListener(onClickListener)
+                    }
+                }
+                is ButtonViewHolder -> {
+                    holder.binding.clearBtn.setOnClickListener {
+                        disposable.add(reportModel.deleteAllReports()
+                            .subscribeOn(Schedulers.io())
+                            .observeOn(AndroidSchedulers.mainThread())
+                            .subscribe {
+                                intent.putExtra(Core.ARG_REPORT_ID, -1)
+                                if (twoPane) {
+                                    val fragment = supportFragmentManager.findFragmentById(R.id.report_detail_container)
+                                    if (fragment != null) {
+                                        supportFragmentManager
+                                            .beginTransaction()
+                                            .detach(fragment)
+                                            .commit()
+
+                                        title = getString(R.string.app_name)
+                                    }
+                                }
+                            })
+                    }
+                }
             }
         }
 
         override fun getItemCount(): Int {
-            return reports.size
+            return if (reports.isEmpty()) 0 else reports.size + 1
         }
 
         inner class ViewHolder(binding: ReportListContentBinding) : RecyclerView.ViewHolder(binding.root) {
@@ -788,6 +798,8 @@ class ReportListActivity : AppCompatActivity(), ReportActivityListener {
                 }
             }
         }
+
+        inner class ButtonViewHolder(val binding: ClearButtonBinding) : RecyclerView.ViewHolder(binding.root)
     }
 
     companion object {
@@ -795,5 +807,7 @@ class ReportListActivity : AppCompatActivity(), ReportActivityListener {
         const val ACCESS_MEDIA_LOCATION_PERMISSION_REQUEST_OPENFILE = 60
         const val ACCESS_MEDIA_LOCATION_PERMISSION_REQUEST_SENDFILE = 61
         const val OPEN_INTENT_PROCESSED = "net.mediaarea.mediainfo.internal.tag.Intent.Processed"
+        const val ITEM_VIEW_TYPE = 0
+        const val BUTTON_VIEW_TYPE = 1
     }
 }

--- a/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/ReportListActivity.kt
+++ b/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/ReportListActivity.kt
@@ -13,7 +13,6 @@ import androidx.activity.result.contract.ActivityResultContracts
 import androidx.annotation.RequiresApi
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.app.AppCompatDelegate
-import androidx.coordinatorlayout.widget.CoordinatorLayout
 import androidx.core.app.ActivityCompat
 import androidx.core.content.edit
 import androidx.core.net.toUri
@@ -665,15 +664,6 @@ class ReportListActivity : AppCompatActivity(), ReportActivityListener {
                     .detach(fragment)
                     .commit()
             }
-        }
-
-        val addButtonParams = activityReportListBinding.addButton.layoutParams as CoordinatorLayout.LayoutParams
-        if (twoPane) {
-            addButtonParams.anchorId = R.id.report_list
-            addButtonParams.gravity = Gravity.BOTTOM or Gravity.START
-        } else {
-            addButtonParams.anchorId = R.id.report_list_layout
-            addButtonParams.gravity = Gravity.BOTTOM or Gravity.END
         }
 
         setupRecyclerView(activityReportListBinding.reportListLayout.reportList)

--- a/Source/GUI/Android/app/src/main/res/layout-w900dp/report_list.xml
+++ b/Source/GUI/Android/app/src/main/res/layout-w900dp/report_list.xml
@@ -22,40 +22,19 @@
 
     <!-- This layout is a two-pane layout for the master/detail flow. -->
 
-    <androidx.core.widget.NestedScrollView
-        android:id="@+id/report_list_scrollview"
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/report_list"
+        android:name="net.mediaarea.mediainfo.ReportListFragment"
         android:layout_width="@dimen/item_width"
         android:layout_height="match_parent"
-        android:layout_marginLeft="2dp"
-        android:layout_marginRight="2dp"
         app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
         tools:context="net.mediaarea.mediainfo.ReportListActivity"
-        >
-        <LinearLayout
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            android:orientation="vertical">
-            <androidx.recyclerview.widget.RecyclerView
-                android:id="@+id/report_list"
-                android:name="net.mediaarea.mediainfo.ReportListFragment"
-                android:layout_width="match_parent"
-                android:layout_height="wrap_content"
-                app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-                tools:context="net.mediaarea.mediainfo.ReportListActivity"
-                tools:listitem="@layout/report_list_content" />
-            <Button
-                android:id="@+id/clear_btn"
-                android:layout_width="wrap_content"
-                android:layout_height="wrap_content"
-                android:textColor="@color/md_theme_onSurfaceVariant"
-                android:text="@string/clear_text"
-                android:layout_gravity="center"
-                style="@style/Widget.AppCompat.Button.Borderless" />
-            <View
-                android:layout_width="match_parent"
-                android:layout_height="@dimen/button_bottom_clearance" />
-        </LinearLayout>
-    </androidx.core.widget.NestedScrollView>
+        tools:listitem="@layout/report_list_content"
+        android:paddingBottom="@dimen/button_bottom_clearance"
+        android:clipToPadding="false"
+        android:scrollbars="vertical"
+        android:scrollbarStyle="outsideOverlay" />
+
     <FrameLayout
         android:id="@+id/report_detail_container"
         android:layout_width="0dp"

--- a/Source/GUI/Android/app/src/main/res/layout/activity_report_list.xml
+++ b/Source/GUI/Android/app/src/main/res/layout/activity_report_list.xml
@@ -35,14 +35,20 @@
         <include android:id="@+id/report_list_layout" layout="@layout/report_list" />
     </FrameLayout>
 
-    <com.google.android.material.floatingactionbutton.FloatingActionButton
-        android:id="@+id/add_button"
+    <FrameLayout
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:layout_gravity="bottom|end"
-        android:layout_margin="@dimen/button_margin"
-        android:contentDescription="@string/open_title"
-        app:layout_anchorGravity="bottom|end"
-        app:srcCompat="@drawable/ic_action_add" />
+        android:layout_gravity="bottom|start"
+        app:layout_anchor="@+id/report_list"
+        app:layout_anchorGravity="bottom|end">
+        <com.google.android.material.floatingactionbutton.FloatingActionButton
+            android:id="@+id/add_button"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_gravity="bottom|end"
+            android:layout_margin="@dimen/button_margin"
+            android:contentDescription="@string/open_title"
+            app:srcCompat="@drawable/ic_action_add" />
+    </FrameLayout>
 
 </androidx.coordinatorlayout.widget.CoordinatorLayout>

--- a/Source/GUI/Android/app/src/main/res/layout/clear_button.xml
+++ b/Source/GUI/Android/app/src/main/res/layout/clear_button.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Button
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    android:id="@+id/clear_btn"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content"
+    android:textColor="@color/md_theme_onSurfaceVariant"
+    android:text="@string/clear_text"
+    android:layout_gravity="center"
+    style="@style/Widget.AppCompat.Button.Borderless" />

--- a/Source/GUI/Android/app/src/main/res/layout/report_list.xml
+++ b/Source/GUI/Android/app/src/main/res/layout/report_list.xml
@@ -6,36 +6,23 @@
       be found in the License.html file in the root of the source tree.
 -->
 
-<androidx.core.widget.NestedScrollView
+<LinearLayout
     xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:layout_marginLeft="2dp"
-    android:layout_marginRight="2dp">
-    <LinearLayout
+    android:orientation="vertical">
+    <androidx.recyclerview.widget.RecyclerView
+        android:id="@+id/report_list"
+        android:name="net.mediaarea.mediainfo.ReportListFragment"
         android:layout_width="match_parent"
-        android:layout_height="wrap_content"
-        android:orientation="vertical">
-        <androidx.recyclerview.widget.RecyclerView
-            android:id="@+id/report_list"
-            android:name="net.mediaarea.mediainfo.ReportListFragment"
-            android:layout_width="match_parent"
-            android:layout_height="wrap_content"
-            app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
-            tools:context=".ReportListActivity"
-            tools:listitem="@layout/report_list_content" />
-        <Button
-            android:id="@+id/clear_btn"
-            android:layout_width="wrap_content"
-            android:layout_height="wrap_content"
-            android:textColor="@color/md_theme_onSurfaceVariant"
-            android:text="@string/clear_text"
-            android:layout_gravity="center"
-            style="@style/Widget.AppCompat.Button.Borderless" />
-        <View
-            android:layout_width="match_parent"
-            android:layout_height="@dimen/button_bottom_clearance" />
-    </LinearLayout>
-</androidx.core.widget.NestedScrollView>
+        android:layout_height="match_parent"
+        app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
+        tools:context=".ReportListActivity"
+        tools:listitem="@layout/report_list_content"
+        android:paddingBottom="@dimen/button_bottom_clearance"
+        android:clipToPadding="false"
+        android:scrollbars="vertical"
+        android:scrollbarStyle="outsideOverlay" />
+</LinearLayout>


### PR DESCRIPTION
Get the RecyclerView out of NestedScrollView so that it can work properly and should have better performance and efficiency. Also show scrollbar so that users have an idea how long their report list is.

FAB positioning is now done with XML since we have RecyclerView with a fixed ID that can anchor to. Also put it in a FrameLayout so that it has similar margins when in two pane mode.
