### PR TITLE
ShellExt: Add generated include path and overrides

### DIFF
--- a/Project/MSVC2022/MediaInfo_WindowsShellExtension/MediaInfo_WindowsShellExtension.vcxproj
+++ b/Project/MSVC2022/MediaInfo_WindowsShellExtension/MediaInfo_WindowsShellExtension.vcxproj
@@ -147,34 +147,43 @@
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Qt|Win32'">
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Qt|x64'">
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Qt|ARM64'">
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/Project/MSVC2026/MediaInfo_WindowsShellExtension/MediaInfo_WindowsShellExtension.vcxproj
+++ b/Project/MSVC2026/MediaInfo_WindowsShellExtension/MediaInfo_WindowsShellExtension.vcxproj
@@ -146,34 +146,43 @@
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Qt|Win32'">
     <OutDir>$(SolutionDir)$(Platform)\$(Configuration)\</OutDir>
     <IntDir>$(Platform)\$(Configuration)\</IntDir>
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Qt|x64'">
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release Qt|ARM64'">
     <RunCodeAnalysis>true</RunCodeAnalysis>
+    <IncludePath>$(IntDir)Generated Files;$(IncludePath)</IncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>

--- a/Project/MSVC2026/MediaInfo_WindowsShellExtension/MediaInfo_WindowsShellExtension.vcxproj.filters
+++ b/Project/MSVC2026/MediaInfo_WindowsShellExtension/MediaInfo_WindowsShellExtension.vcxproj.filters
@@ -44,4 +44,8 @@
       <Filter>Source Files</Filter>
     </None>
   </ItemGroup>
+  <ItemGroup>
+    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natvis" />
+    <Natvis Include="$(MSBuildThisFileDirectory)..\..\natvis\wil.natstepfilter" />
+  </ItemGroup>
 </Project>

--- a/Source/WindowsShellExtension/dllmain.cpp
+++ b/Source/WindowsShellExtension/dllmain.cpp
@@ -425,13 +425,13 @@ struct ExplorerCommandHandler : public winrt::implements<ExplorerCommandHandler,
 public:
     // IExplorerCommand implementation:
 
-    IFACEMETHODIMP GetTitle(_In_opt_ IShellItemArray* items, _Outptr_ PWSTR* name) {
+    IFACEMETHODIMP GetTitle(_In_opt_ IShellItemArray* items, _Outptr_ PWSTR* name) override {
         // Provide name for display in File Explorer context menu entry
         UNREFERENCED_PARAMETER(items);
         return SHStrDupW(menu_entry_title, name);
     }
 
-    IFACEMETHODIMP GetIcon(_In_opt_ IShellItemArray* items, _Outptr_ PWSTR* icon) {
+    IFACEMETHODIMP GetIcon(_In_opt_ IShellItemArray* items, _Outptr_ PWSTR* icon) override {
         // Provide icon for display in File Explorer context menu entry
         // Get path to application exe and use it as source for icon
         UNREFERENCED_PARAMETER(items);
@@ -441,18 +441,18 @@ public:
         return SHStrDupW(module_path.c_str(), icon);
     }
 
-    IFACEMETHODIMP GetToolTip(_In_opt_ IShellItemArray* items, _Outptr_ PWSTR* infoTip) {
+    IFACEMETHODIMP GetToolTip(_In_opt_ IShellItemArray* items, _Outptr_ PWSTR* infoTip) override {
         UNREFERENCED_PARAMETER(items);
         *infoTip = nullptr;
         return E_NOTIMPL;
     }
 
-    IFACEMETHODIMP GetCanonicalName(_Out_ GUID* guidCommandName) {
+    IFACEMETHODIMP GetCanonicalName(_Out_ GUID* guidCommandName) override {
         *guidCommandName = GUID_NULL;
         return S_OK;
     }
 
-    IFACEMETHODIMP GetState(_In_opt_ IShellItemArray* items, _In_ BOOL okToBeSlow, _Out_ EXPCMDSTATE* cmdState) {
+    IFACEMETHODIMP GetState(_In_opt_ IShellItemArray* items, _In_ BOOL okToBeSlow, _Out_ EXPCMDSTATE* cmdState) override {
         // Provide state of File Explorer context menu entry
         // Hide it if registry setting indicates that it should be disabled or file is unsupported, else it is enabled
 
@@ -534,17 +534,17 @@ public:
         return S_OK;
     }
 
-    IFACEMETHODIMP GetFlags(_Out_ EXPCMDFLAGS* flags) {
+    IFACEMETHODIMP GetFlags(_Out_ EXPCMDFLAGS* flags) override {
         *flags = ECF_DEFAULT;
         return S_OK;
     }
 
-    IFACEMETHODIMP EnumSubCommands(_Outptr_ IEnumExplorerCommand** enumCommands) {
+    IFACEMETHODIMP EnumSubCommands(_Outptr_ IEnumExplorerCommand** enumCommands) override {
         *enumCommands = nullptr;
         return E_NOTIMPL;
     }
 
-    IFACEMETHODIMP Invoke(_In_opt_ IShellItemArray* items, _In_opt_ IBindCtx* bindCtx) {
+    IFACEMETHODIMP Invoke(_In_opt_ IShellItemArray* items, _In_opt_ IBindCtx* bindCtx) override {
         // Process items passed by File Explorer when context menu entry is invoked
         UNREFERENCED_PARAMETER(bindCtx);
 


### PR DESCRIPTION
Just some improvements that does not affect compiled code.

- Add override to IExplorerCommand methods.
  - For correctness and to avoid warnings in some static analyzers.
- Add Generated Files to include path.
  - This solves the annoying case where Intellisense shows red warnings due to winrt headers not yet being generated then not seeing it after the project is built once.
  - With this change, just need to build project once to generate winrt headers then select 'Refresh browsing database' to refresh Intellisense and it will see the headers are now present.
- Also vcxproj.filters updated by itself to match what MSVC2022 one already has.
