### PR TITLE
Android: Fix geolocation help dialog display logic

### DIFF
--- a/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/ReportListActivity.kt
+++ b/Source/GUI/Android/app/src/main/java/net/mediaarea/mediainfo/ReportListActivity.kt
@@ -96,17 +96,6 @@ class ReportListActivity : AppCompatActivity(), ReportActivityListener {
     override fun onRequestPermissionsResult(requestCode: Int, permissions: Array<String>, grantResults: IntArray) {
         super.onRequestPermissionsResult(requestCode, permissions, grantResults)
 
-        // If user wants to enable ACCESS_MEDIA_LOCATION permission, but the prompt has been blocked
-        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
-            && permissions.isNotEmpty() && grantResults.isNotEmpty()
-            && permissions[0] == android.Manifest.permission.ACCESS_MEDIA_LOCATION
-            && grantResults[0] == PackageManager.PERMISSION_DENIED
-            && !shouldShowRequestPermissionRationale(permissions[0])) {
-            showGeolocationHelpDialog()
-            pendingFileUris.clear()
-            return
-        }
-
         // Handle result
         when (requestCode) {
             READ_EXTERNAL_STORAGE_PERMISSION_REQUEST -> {
@@ -133,17 +122,6 @@ class ReportListActivity : AppCompatActivity(), ReportActivityListener {
         intent.addCategory(Intent.CATEGORY_DEFAULT)
         intent.data = "package:${this.packageName}".toUri()
         startActivity(intent)
-    }
-
-    private fun showGeolocationHelpDialog() {
-        MaterialAlertDialogBuilder(this)
-            .setTitle(R.string.permissions_geolocation_title)
-            .setMessage(R.string.permissions_geolocation_help)
-            .setPositiveButton(android.R.string.ok) { _, _ ->
-                openPermissionsSettings()
-            }
-            .setNegativeButton(android.R.string.cancel, null)
-            .show()
     }
 
     override fun onConfigurationChanged(newConfig: Configuration) {
@@ -194,28 +172,27 @@ class ReportListActivity : AppCompatActivity(), ReportActivityListener {
 
     @RequiresApi(Build.VERSION_CODES.Q)
     private fun requestMediaLocationPermission(requestCode: Int) {
-        MaterialAlertDialogBuilder(this)
-            .setTitle(R.string.permissions_geolocation_title)
-            .setMessage(R.string.permissions_geolocation_summary)
-            .setPositiveButton(android.R.string.ok) { _, _ ->
-                ActivityCompat.requestPermissions(
-                    this@ReportListActivity,
-                    arrayOf(android.Manifest.permission.ACCESS_MEDIA_LOCATION),
-                    requestCode
-                )
-            }
-            .setNegativeButton(android.R.string.cancel) { _, _ ->
-                when (requestCode) {
-                    ACCESS_MEDIA_LOCATION_PERMISSION_REQUEST_OPENFILE -> {
-                        openFile.launch("*/*") // Lets user open files anyway, even if the location data may be redacted out
-                    }
-                    ACCESS_MEDIA_LOCATION_PERMISSION_REQUEST_SENDFILE -> {
-                        reportModel.addFiles(contentResolver, pendingFileUris.toList()) // Create a copy of pendingFileUris to avoid getting a cleared item in reportModel.addFiles@viewModelScope subroutine
-                        pendingFileUris.clear()
-                    }
+        if (shouldShowRequestPermissionRationale(android.Manifest.permission.ACCESS_MEDIA_LOCATION)) {
+            MaterialAlertDialogBuilder(this)
+                .setTitle(R.string.permissions_geolocation_title)
+                .setMessage(R.string.permissions_geolocation_summary)
+                .setCancelable(false)
+                .setPositiveButton(android.R.string.ok) { _, _ ->
+                    ActivityCompat.requestPermissions(
+                        this@ReportListActivity,
+                        arrayOf(android.Manifest.permission.ACCESS_MEDIA_LOCATION),
+                        requestCode
+                    )
                 }
-            }
-            .show()
+                .show()
+        }
+        else {
+            ActivityCompat.requestPermissions(
+                this@ReportListActivity,
+                arrayOf(android.Manifest.permission.ACCESS_MEDIA_LOCATION),
+                requestCode
+            )
+        }
     }
 
     private fun handleIntent(intent: Intent) {


### PR DESCRIPTION
Fixes #1301 

[Snapshot](https://mediaarea.net/download/snapshots/branches/binary/mediainfo-gui/20260725_permission-request/MediaInfo_GUI_26.05.20260725_Android.apk)