### PR TITLE
CLI: Document HideParameter and ShowParameter options in help output

### DIFF
--- a/Source/CLI/Help.cpp
+++ b/Source/CLI/Help.cpp
@@ -87,6 +87,15 @@ int Help()
     TEXTOUT("                    Output template for external metadata (EBUCore output)");
     TEXTOUT("--Info-Parameters");
     TEXTOUT("                    Display list of Inform= parameters");
+    TEXTOUT("--HideParameter=...");
+    TEXTOUT("                    Hide the specified field(s) from Text, CSV, HTML, XML and JSON output.");
+    TEXTOUT("                    Value is StreamKind_FieldName (StreamKind is General, Video, Audio, Text,");
+    TEXTOUT("                    Other, Image or Menu), comma-separated for multiple fields.");
+    TEXTOUT("                    Example: --HideParameter=General_CodecID_Compatible");
+    TEXTOUT("                    Note: overridden by --Full/-f, which always shows all fields.");
+    TEXTOUT("--ShowParameter=...");
+    TEXTOUT("                    Re-show (or force-show) the specified field(s), reversing --HideParameter");
+    TEXTOUT("                    or a field's default visibility. Same value format as --HideParameter.");
     TEXTOUT("");
     TEXTOUT("--Language=raw");
     TEXTOUT("                    Display non-translated unique identifiers (internal text)");


### PR DESCRIPTION
Added `--HideParameter` and `--ShowParameter` documentation to the help output next to `--Info-Parameters`. This doesn't include any functional changes, only to Help.cpp. HideParameter is useful (but up until now, undocumented) since it can be used to ignore fields with problematic data, such as "General_CodecID_Compatible" or "General_CodecID/String" for certain odd files that were authored incorrectly.